### PR TITLE
Update on DC plots for timelines

### DIFF
--- a/detectors/src/main/java/org/jlab/clas/timeline/fitter/DCFitter.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/fitter/DCFitter.groovy
@@ -45,6 +45,41 @@ class DCFitter{
 
  	}
 
+
+	static F1D doublegausfit(H1F h1) {
+        def f1 = new F1D("fit:"+h1.getName(), "[amp]*gaus(x,[mean],[sigma])+[const]", -0.5, 0.5);
+
+        double hAmp  = h1.getBinContent(h1.getMaximumBin());
+        double hMean = h1.getAxis().getBinCenter(h1.getMaximumBin());
+        double hRMS  = h1.getRMS(); //ns
+        f1.setRange(hMean-1, hMean+1);
+        f1.setParameter(0, hAmp);
+        f1.setParameter(1, hMean);
+        f1.setParLimits(1, hMean-0.5, hMean+0.5);
+        f1.setParameter(2, hRMS);
+        f1.setParameter(3,0);
+ 
+	    DataFitter.fit(f1,h1,"LQ")
+
+        //refit using a double gaussian 
+        def gausFunc2 = new F1D("gausFunc2:"+h1.getName(), "[amp]*gaus(x,[mean],[sigma])+[amp2]*gaus(x,[mean],[sigma2])", -0.5, 0.5); 
+        gausFunc2.setParameter(0, f1.getParameter(0));
+        gausFunc2.setParameter(1, f1.getParameter(1));
+        gausFunc2.setParameter(2, f1.getParameter(2)*0.75);
+        gausFunc2.setParameter(3, f1.getParameter(0)*0.15);
+        gausFunc2.setParameter(4, f1.getParameter(2));
+
+       
+        
+        DataFitter.fit(gausFunc2, h1, "LQ");
+
+		return gausFunc2
+
+ 	}
+
+
+
+
  	static F1D t0fit(H1F h1, int slayer){
 
     	def f1 = new F1D("fit:"+h1.getName(),"[p0]/(1+exp(-[p1]*(x-[p2])))",-100,1000);

--- a/detectors/src/main/java/org/jlab/clas/timeline/run.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/run.groovy
@@ -100,6 +100,8 @@ def engines = [
     new ftof.ftof_tdcadc_p2_zoomed(),
     new dc.dc_residuals_sec(),
     new dc.dc_residuals_sec_sl(),
+    new dc.dc_residuals_sec_rescut(),
+    new dc.dc_residuals_sec_sl_rescut(),
     new dc.dc_t0_sec_sl(),
     new dc.dc_tmax_sec_sl()],
   out_RICH: [new rich.rich_timediff(),

--- a/detectors/src/main/java/org/jlab/clas/timeline/run_rgb.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/run_rgb.groovy
@@ -105,6 +105,8 @@ def engines = [
     new ftof.ftof_tdcadc_p2_zoomed(),
     new dc.dc_residuals_sec(),
     new dc.dc_residuals_sec_sl(),
+    new dc.dc_residuals_sec_rescut(),
+    new dc.dc_residuals_sec_sl_rescut(),
     new dc.dc_t0_sec_sl(),
     new dc.dc_tmax_sec_sl()],
   out_RICH: [new rich.rich_timediff(),

--- a/detectors/src/main/java/org/jlab/clas/timeline/timeline/dc/dc_residuals_sec.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/timeline/dc/dc_residuals_sec.groovy
@@ -16,8 +16,8 @@ def processDirectory(dir, run) {
   def histlist =   (0..<6).collect{sec->
     def h1 = dir.getObject(String.format('/dc/DC_residuals_trkDoca_%d_%d',(sec+1),1)).projectionY()
     h1.setName("sec"+(sec+1))
-    h1.setTitle("DC residuals per sector per superlayer")
-    h1.setTitleX("DC residuals per sector per superlayer (cm)")
+    h1.setTitle("DC residuals per sector per superlayer (with basic DC4gui cuts)")
+    h1.setTitleX("DC residuals per sector per superlayer (with basic DC4gui cuts) (cm)")
     (1..<6).each{sl ->
       def h2 = dir.getObject(String.format('/dc/DC_residuals_trkDoca_%d_%d',(sec+1),(sl+1))).projectionY()
       h1.add(h2)
@@ -41,8 +41,8 @@ def close() {
     out.mkdir('/timelines')
     (0..<6).each{ sec->
         def grtl = new GraphErrors('sec'+(sec+1))
-        grtl.setTitle("DC residuals (" + name + ") per sector per superlayer")
-        grtl.setTitleY("DC residuals (" + name + ") per sector per superlayer (cm)")
+        grtl.setTitle("DC residuals (" + name + ") per sector per superlayer (with basic DC4gui cuts)")
+        grtl.setTitleY("DC residuals (" + name + ") per sector per superlayer (with basic DC4gui cuts) (cm)")
         grtl.setTitleX("run number")
 
         data.sort{it.key}.each{run,it->

--- a/detectors/src/main/java/org/jlab/clas/timeline/timeline/dc/dc_residuals_sec_rescut.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/timeline/dc/dc_residuals_sec_rescut.groovy
@@ -22,7 +22,7 @@ def processDirectory(dir, run) {
       def h2 = dir.getObject(String.format('/dc/DC_residuals_trkDoca_rescut_%d_%d',(sec+1),(sl+1))).projectionY()
       h1.add(h2)
     }
-    def f1 = DCFitter.fit(h1)
+    def f1 = DCFitter.doublegausfit(h1)
     funclist.add(f1)
     meanlist.add(f1.getParameter(1))
     sigmalist.add(f1.getParameter(2).abs())

--- a/detectors/src/main/java/org/jlab/clas/timeline/timeline/dc/dc_residuals_sec_rescut.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/timeline/dc/dc_residuals_sec_rescut.groovy
@@ -1,0 +1,62 @@
+package org.jlab.clas.timeline.timeline.dc
+import java.util.concurrent.ConcurrentHashMap
+import org.jlab.groot.data.TDirectory
+import org.jlab.groot.data.GraphErrors
+import org.jlab.clas.timeline.fitter.DCFitter
+
+class dc_residuals_sec {
+
+def data = new ConcurrentHashMap()
+
+def processDirectory(dir, run) {
+  def funclist = []
+  def meanlist = []
+  def sigmalist = []
+  def chi2list = []
+  def histlist =   (0..<6).collect{sec->
+    def h1 = dir.getObject(String.format('/dc/DC_residuals_trkDoca_%d_%d',(sec+1),1)).projectionY()
+    h1.setName("sec"+(sec+1))
+    h1.setTitle("DC residuals per sector per superlayer")
+    h1.setTitleX("DC residuals per sector per superlayer (cm)")
+    (1..<6).each{sl ->
+      def h2 = dir.getObject(String.format('/dc/DC_residuals_trkDoca_%d_%d',(sec+1),(sl+1))).projectionY()
+      h1.add(h2)
+    }
+    def f1 = DCFitter.fit(h1)
+    funclist.add(f1)
+    meanlist.add(f1.getParameter(1))
+    sigmalist.add(f1.getParameter(2).abs())
+    chi2list.add(f1.getChiSquare())
+    return h1
+  }
+  data[run] = [run:run, hlist:histlist, flist:funclist, mean:meanlist, sigma:sigmalist, clist:chi2list]
+}
+
+
+
+def close() {
+
+  ['mean', 'sigma'].each{ name ->
+    TDirectory out = new TDirectory()
+    out.mkdir('/timelines')
+    (0..<6).each{ sec->
+        def grtl = new GraphErrors('sec'+(sec+1))
+        grtl.setTitle("DC residuals (" + name + ") per sector per superlayer")
+        grtl.setTitleY("DC residuals (" + name + ") per sector per superlayer (cm)")
+        grtl.setTitleX("run number")
+
+        data.sort{it.key}.each{run,it->
+          if (sec==0) out.mkdir('/'+it.run)
+          out.cd('/'+it.run)
+          out.addDataSet(it.hlist[sec])
+          out.addDataSet(it.flist[sec])
+          grtl.addPoint(it.run, it[name][sec], 0, 0)
+        }
+        out.cd('/timelines')
+        out.addDataSet(grtl)
+    }
+
+    out.writeFile('dc_residuals_sec_'+name+'.hipo')
+  }
+}
+}

--- a/detectors/src/main/java/org/jlab/clas/timeline/timeline/dc/dc_residuals_sec_rescut.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/timeline/dc/dc_residuals_sec_rescut.groovy
@@ -4,7 +4,7 @@ import org.jlab.groot.data.TDirectory
 import org.jlab.groot.data.GraphErrors
 import org.jlab.clas.timeline.fitter.DCFitter
 
-class dc_residuals_sec {
+class dc_residuals_sec_rescut {
 
 def data = new ConcurrentHashMap()
 
@@ -14,12 +14,12 @@ def processDirectory(dir, run) {
   def sigmalist = []
   def chi2list = []
   def histlist =   (0..<6).collect{sec->
-    def h1 = dir.getObject(String.format('/dc/DC_residuals_trkDoca_%d_%d',(sec+1),1)).projectionY()
+    def h1 = dir.getObject(String.format('/dc/DC_residuals_trkDoca_rescut_%d_%d',(sec+1),1)).projectionY()
     h1.setName("sec"+(sec+1))
-    h1.setTitle("DC residuals per sector per superlayer")
-    h1.setTitleX("DC residuals per sector per superlayer (cm)")
+    h1.setTitle("DC residuals per sector per superlayer with fitresidual cut")
+    h1.setTitleX("DC residuals per sector per superlayer with fitresidual cut (cm)")
     (1..<6).each{sl ->
-      def h2 = dir.getObject(String.format('/dc/DC_residuals_trkDoca_%d_%d',(sec+1),(sl+1))).projectionY()
+      def h2 = dir.getObject(String.format('/dc/DC_residuals_trkDoca_rescut_%d_%d',(sec+1),(sl+1))).projectionY()
       h1.add(h2)
     }
     def f1 = DCFitter.fit(h1)
@@ -41,8 +41,8 @@ def close() {
     out.mkdir('/timelines')
     (0..<6).each{ sec->
         def grtl = new GraphErrors('sec'+(sec+1))
-        grtl.setTitle("DC residuals (" + name + ") per sector per superlayer")
-        grtl.setTitleY("DC residuals (" + name + ") per sector per superlayer (cm)")
+        grtl.setTitle("DC residuals (" + name + ") per sector per superlayer with fitresidual cut")
+        grtl.setTitleY("DC residuals (" + name + ") per sector per superlayer with fitresidual cut (cm)")
         grtl.setTitleX("run number")
 
         data.sort{it.key}.each{run,it->
@@ -56,7 +56,7 @@ def close() {
         out.addDataSet(grtl)
     }
 
-    out.writeFile('dc_residuals_sec_'+name+'.hipo')
+    out.writeFile('dc_residuals_sec_rescut_'+name+'.hipo')
   }
 }
 }

--- a/detectors/src/main/java/org/jlab/clas/timeline/timeline/dc/dc_residuals_sec_sl.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/timeline/dc/dc_residuals_sec_sl.groovy
@@ -16,8 +16,8 @@ def processDirectory(dir, run) {
   def histlist =   (0..<6).collect{sec-> (0..<6).collect{sl ->
       def h1 = dir.getObject(String.format('/dc/DC_residuals_trkDoca_%d_%d',(sec+1),(sl+1))).projectionY()
       h1.setName("sec"+(sec+1)+"sl"+(sl+1))
-      h1.setTitle("DC residuals per sector per superlayer")
-      h1.setTitleX("DC residuals per sector per superlayer (cm)")
+      h1.setTitle("DC residuals per sector per superlayer (with basic DC4gui cuts)")
+      h1.setTitleX("DC residuals per sector per superlayer (with basic DC4gui cuts) (cm)")
       def f1 = DCFitter.fit(h1)
       funclist[sec].add(f1)
       meanlist[sec].add(f1.getParameter(1))
@@ -40,8 +40,8 @@ def close() {
     (0..<6).each{ sec->
       (0..<6).each{sl->
         def grtl = new GraphErrors('sec'+(sec+1)+' sl'+(sl+1))
-        grtl.setTitle("DC residuals (" + name + ") per sector per superlayer")
-        grtl.setTitleY("DC residuals (" + name + ") per sector per superlayer (cm)")
+        grtl.setTitle("DC residuals (" + name + ") per sector per superlayer (with basic DC4gui cuts)")
+        grtl.setTitleY("DC residuals (" + name + ") per sector per superlayer (with basic DC4gui cuts) (cm)")
         grtl.setTitleX("run number")
 
         data.sort{it.key}.each{run,it->

--- a/detectors/src/main/java/org/jlab/clas/timeline/timeline/dc/dc_residuals_sec_sl_rescut.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/timeline/dc/dc_residuals_sec_sl_rescut.groovy
@@ -1,0 +1,62 @@
+package org.jlab.clas.timeline.timeline.dc
+import java.util.concurrent.ConcurrentHashMap
+import org.jlab.groot.data.TDirectory
+import org.jlab.groot.data.GraphErrors
+import org.jlab.clas.timeline.fitter.DCFitter
+
+class dc_residuals_sec_sl {
+
+def data = new ConcurrentHashMap()
+
+def processDirectory(dir, run) {
+  def funclist = [[],[],[],[],[],[]]
+  def meanlist = [[],[],[],[],[],[]]
+  def sigmalist = [[],[],[],[],[],[]]
+  def chi2list = [[],[],[],[],[],[]]
+  def histlist =   (0..<6).collect{sec-> (0..<6).collect{sl ->
+      def h1 = dir.getObject(String.format('/dc/DC_residuals_trkDoca_%d_%d',(sec+1),(sl+1))).projectionY()
+      h1.setName("sec"+(sec+1)+"sl"+(sl+1))
+      h1.setTitle("DC residuals per sector per superlayer")
+      h1.setTitleX("DC residuals per sector per superlayer (cm)")
+      def f1 = DCFitter.fit(h1)
+      funclist[sec].add(f1)
+      meanlist[sec].add(f1.getParameter(1))
+      sigmalist[sec].add(f1.getParameter(2).abs())
+      chi2list[sec].add(f1.getChiSquare())
+      return h1
+    }
+  }
+
+  data[run] = [run:run, hlist:histlist, flist:funclist, mean:meanlist, sigma:sigmalist, clist:chi2list]
+}
+
+
+
+def close() {
+
+  ['mean', 'sigma'].each{ name ->
+    TDirectory out = new TDirectory()
+    out.mkdir('/timelines')
+    (0..<6).each{ sec->
+      (0..<6).each{sl->
+        def grtl = new GraphErrors('sec'+(sec+1)+' sl'+(sl+1))
+        grtl.setTitle("DC residuals (" + name + ") per sector per superlayer")
+        grtl.setTitleY("DC residuals (" + name + ") per sector per superlayer (cm)")
+        grtl.setTitleX("run number")
+
+        data.sort{it.key}.each{run,it->
+          if (sec==0 && sl==0) out.mkdir('/'+it.run)
+          out.cd('/'+it.run)
+          out.addDataSet(it.hlist[sec][sl])
+          out.addDataSet(it.flist[sec][sl])
+          grtl.addPoint(it.run, it[name][sec][sl], 0, 0)
+        }
+        out.cd('/timelines')
+        out.addDataSet(grtl)
+      }
+    }
+
+    out.writeFile('dc_residuals_sec_sl_'+name+'.hipo')
+  }
+}
+}

--- a/detectors/src/main/java/org/jlab/clas/timeline/timeline/dc/dc_residuals_sec_sl_rescut.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/timeline/dc/dc_residuals_sec_sl_rescut.groovy
@@ -4,7 +4,7 @@ import org.jlab.groot.data.TDirectory
 import org.jlab.groot.data.GraphErrors
 import org.jlab.clas.timeline.fitter.DCFitter
 
-class dc_residuals_sec_sl {
+class dc_residuals_sec_sl_rescut {
 
 def data = new ConcurrentHashMap()
 
@@ -14,10 +14,10 @@ def processDirectory(dir, run) {
   def sigmalist = [[],[],[],[],[],[]]
   def chi2list = [[],[],[],[],[],[]]
   def histlist =   (0..<6).collect{sec-> (0..<6).collect{sl ->
-      def h1 = dir.getObject(String.format('/dc/DC_residuals_trkDoca_%d_%d',(sec+1),(sl+1))).projectionY()
+      def h1 = dir.getObject(String.format('/dc/DC_residuals_trkDoca_rescut_%d_%d',(sec+1),(sl+1))).projectionY()
       h1.setName("sec"+(sec+1)+"sl"+(sl+1))
-      h1.setTitle("DC residuals per sector per superlayer")
-      h1.setTitleX("DC residuals per sector per superlayer (cm)")
+      h1.setTitle("DC residuals per sector per superlayer with fitresidual cut")
+      h1.setTitleX("DC residuals per sector per superlayer with fitresidual cut (cm)")
       def f1 = DCFitter.fit(h1)
       funclist[sec].add(f1)
       meanlist[sec].add(f1.getParameter(1))
@@ -40,8 +40,8 @@ def close() {
     (0..<6).each{ sec->
       (0..<6).each{sl->
         def grtl = new GraphErrors('sec'+(sec+1)+' sl'+(sl+1))
-        grtl.setTitle("DC residuals (" + name + ") per sector per superlayer")
-        grtl.setTitleY("DC residuals (" + name + ") per sector per superlayer (cm)")
+        grtl.setTitle("DC residuals (" + name + ") per sector per superlayer with fitresidual cut")
+        grtl.setTitleY("DC residuals (" + name + ") per sector per superlayer with fitresidual cut (cm)")
         grtl.setTitleX("run number")
 
         data.sort{it.key}.each{run,it->
@@ -56,7 +56,7 @@ def close() {
       }
     }
 
-    out.writeFile('dc_residuals_sec_sl_'+name+'.hipo')
+    out.writeFile('dc_residuals_sec_sl_rescut_'+name+'.hipo')
   }
 }
 }

--- a/detectors/src/main/java/org/jlab/clas/timeline/timeline/dc/dc_residuals_sec_sl_rescut.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/timeline/dc/dc_residuals_sec_sl_rescut.groovy
@@ -18,9 +18,10 @@ def processDirectory(dir, run) {
       h1.setName("sec"+(sec+1)+"sl"+(sl+1))
       h1.setTitle("DC residuals per sector per superlayer with fitresidual cut")
       h1.setTitleX("DC residuals per sector per superlayer with fitresidual cut (cm)")
-      def f1 = DCFitter.fit(h1)
+      def f1 = DCFitter.doublegausfit(h1)
       funclist[sec].add(f1)
       meanlist[sec].add(f1.getParameter(1))
+      //sigma just from smaller gaus for now
       sigmalist[sec].add(f1.getParameter(2).abs())
       chi2list[sec].add(f1.getChiSquare())
       return h1


### PR DESCRIPTION
Update for DC plots. Added new set of timelines for histograms with cuts similar to DC4gui (Repository: https://github.com/JeffersonLab/clas12calibration-dc, function passCalibCuts in https://github.com/JeffersonLab/clas12calibration-dc/blob/master/src/main/java/org/clas/detector/clas12calibration/dc/calt2d/T2DCalib.java). Also add double gaussian fitter But only take smaller sigma for timelines (no weighting with amplitude as it is done in DC4gui).

This update has been tested by Justin on RGM and RGB data (thank you). It requires also updated monitoring code.