### PR TITLE
DC monitoring: removed ddoca term from filling residuals

### DIFF
--- a/monitoring/src/main/java/org/jlab/clas12/monitoring/tof_monitor.java
+++ b/monitoring/src/main/java/org/jlab/clas12/monitoring/tof_monitor.java
@@ -376,8 +376,8 @@ public class tof_monitor {
 				// if (otherregions||region2) {
 		
 				//Fill Histograms with no extra cut
-				DC_residuals_trkDoca_nocut[s][sl].fill(trkDoca,timeResidual+dDoca);
-				DC_residuals_nocut[s][sl].fill(timeResidual+dDoca);
+				DC_residuals_trkDoca_nocut[s][sl].fill(trkDoca,timeResidual);
+				DC_residuals_nocut[s][sl].fill(timeResidual);
 				DC_time_nocut[s][sl].fill(time);
 				
 				//Add extra cuts on hits from DC4gui. TrkID, beta, alphacut, TFlight (maybe PID?, needs REC::Event here)
@@ -385,8 +385,8 @@ public class tof_monitor {
 					 DCB.getFloat("TFlight",r) > 0 && alphacutpass == true
 						)
 				{
-					DC_residuals_trkDoca[s][sl].fill(trkDoca,timeResidual+dDoca);
-					DC_residuals[s][sl].fill(timeResidual+dDoca);
+					DC_residuals_trkDoca[s][sl].fill(trkDoca,timeResidual);
+					DC_residuals[s][sl].fill(timeResidual);
 					DC_time[s][sl].fill(time);	
 					
 					if( timestamp%2 == 0) {//even time stamps
@@ -397,8 +397,8 @@ public class tof_monitor {
 						}
 				//Apply also fitresidual cut, factor 0.0001 to convert to cm from microns
 					if (DCB.getFloat("fitResidual",r) < 0.0001 * fitresidualcut) {
-						DC_residuals_trkDoca_rescut[s][sl].fill(trkDoca,timeResidual+dDoca);
-						DC_residuals_rescut[s][sl].fill(timeResidual+dDoca);
+						DC_residuals_trkDoca_rescut[s][sl].fill(trkDoca,timeResidual);
+						DC_residuals_rescut[s][sl].fill(timeResidual);
 						DC_time_rescut[s][sl].fill(time);
 					}						
 				}


### PR DESCRIPTION
The ddoca term summations was wrongly added in some previous version before monitoring code was merged with the timeline code.