### PR TITLE
adjust FTOF and CTOF QA limits

### DIFF
--- a/calib-qa/cuts/rga-sp18.txt
+++ b/calib-qa/cuts/rga-sp18.txt
@@ -5,9 +5,9 @@ ltcc  ltcc_elec_nphe_sec         11      14      counts
 
 htcc  htcc_nphe_sec              11      13      counts
 
-ftof  ftof_edep_p1a_midangles    9.0     11.0    MeV
-ftof  ftof_edep_p1b_midangles    11.0    13.0    MeV
-ftof  ftof_edep_p2               9.0     11.0    MeV
+ftof  ftof_edep_p1a_midangles    8.75    10.75   MeV
+ftof  ftof_edep_p1b_midangles    10.5    12.5    MeV
+ftof  ftof_edep_p2               8.75    10.75   MeV
 ftof  ftof_time_p1a_mean         -0.030  0.030   ns
 ftof  ftof_time_p1a_sigma        0       0.135   ns
 ftof  ftof_time_p1b_mean         -0.020  0.020   ns
@@ -32,7 +32,7 @@ ec    ec_pim_time_sigma          -0.200  0.200   ns
 ec    ec_pip_time_mean           -0.040  0.040   ns
 ec    ec_pip_time_sigma          -0.200  0.200   ns
 
-ctof  ctof_edep                  5.7     6.3     MeV
+ctof  ctof_edep                  5.6     6.4     MeV
 ctof  ctof_time_mean             -0.020  0.020   ns
 ctof  ctof_time_sigma            0       0.115   ns
 


### PR DESCRIPTION
As requested by @dcarman:

> FTOF:
> 1) ftof edep p1a midangles QA: (old) 9.0 - 11.0 MeV, (new) 8.75 - 10.75 MeV
> 2) ftof edep p1b midangles QA: (old) 11.0 - 13.0 MeV, (new) 10.5 - 12.5 MeV
> 3) ftof edep p2 QA: (old) 9.0 - 11.0 MeV, (new) 8.75 - 10.75 MeV
> 
> CTOF:
> 1) ctof edep QA: (old) 5.7 - 6.3 MeV, (new) 5.6 - 6.4 MeV