### PR TITLE
doc: replace hard github links with relative links

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ OPTIONS:
                        Each `plots` directory contains hipo files with monitoring histograms.
 </pre>
 
-To run it interactively, see here: https://github.com/JeffersonLab/clas12-timeline/tree/main/monitoring
+To run it interactively, see the [monitoring subdirectory](monitoring)
 
 ##  Timeline
 To build,

--- a/detectors/README.md
+++ b/detectors/README.md
@@ -1,2 +1,2 @@
 # Timeline code
-This the the directory with code for producing timelines. To run it, [look one directory above](..)
+This the the directory with code for producing timelines. To run it, [look one directory above](/../../)

--- a/detectors/README.md
+++ b/detectors/README.md
@@ -1,2 +1,2 @@
 # Timeline code
-This the the directory with code for producing timelines. To run it look one directory above: https://github.com/JeffersonLab/clas12-timeline
+This the the directory with code for producing timelines. To run it, [look one directory above](..)


### PR DESCRIPTION
Use relative links, so that they are functional on any branch.

Does not fix this `calib-qa` one, since #27 will: https://github.com/JeffersonLab/clas12-timeline/blob/bfe82833896c872eddb68904b508890ed0ebe6b1/README.md?plain=1#L66