### PR TITLE
Move to newer coatjava version, make build more general

### DIFF
--- a/bin/build-all.sh
+++ b/bin/build-all.sh
@@ -1,12 +1,10 @@
-#!/usr/bin/bash
+#!/bin/bash
 
-SCRIPTPATH=`realpath $0`
-BINPATH=`dirname $SCRIPTPATH`
-DIRPATH=`dirname $BINPATH`
+d="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 
-cd $DIRPATH/monitoring
+cd $d/../monitoring
 mvn package
 cd -
-cd $DIRPATH/detectors
+cd $d/../detectors
 mvn package
 cd -

--- a/detectors/pom.xml
+++ b/detectors/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>org.jlab.coat</groupId>
       <artifactId>coat-libs</artifactId>
-      <version>8.2.2-SNAPSHOT</version>
+      <version>9.0.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/monitoring/pom.xml
+++ b/monitoring/pom.xml
@@ -9,7 +9,7 @@
       <dependency>
         <groupId>org.jlab.coat</groupId>
         <artifactId>coat-libs</artifactId>
-        <version>8.2.2-SNAPSHOT</version>
+        <version>9.0.0-SNAPSHOT</version>
          <type>jar</type>
       </dependency>
     </dependencies>


### PR DESCRIPTION
* coatjava 8.5.0 or later is necessary for a CCDB update to access certain tables, e.g., for RICH
* make the build system not require "realpath", and assume the standard /bin/bash location