### PR TITLE
fix: do not parse duplicate datasets in `datasetList.txt`

### DIFF
--- a/qa-physics/datasetListParser.sh
+++ b/qa-physics/datasetListParser.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# parse `datasetList.sh`, setting:
+# - `runL`: lower run bound
+# - `runH`: upper run bound
+# - `datadir`: data directory
+# usage: `source $0 $dataset`
+
+if [ $# -ne 1 ]; then
+  echo "ERROR: dataset not specified"
+  exit 100
+fi
+
+line=$(grep -wE "^$dataset" datasetList.txt | tail -n1)
+
+if [ -z "$line" ]; then
+  echo "ERROR: cannot find dataset '$dataset' in datasetList.text"
+  exit 100
+fi
+
+runL=$(echo $line | awk '{print $2}')
+runH=$(echo $line | awk '{print $3}')
+datadir=$(echo $line | awk '{print $4}')
+echo """found dataset '$dataset':
+  runL    = $runL
+  runH    = $runH
+  datadir = $datadir"""

--- a/qa-physics/datasetListParser.sh
+++ b/qa-physics/datasetListParser.sh
@@ -13,7 +13,7 @@ fi
 line=$(grep -wE "^$dataset" datasetList.txt | tail -n1)
 
 if [ -z "$line" ]; then
-  echo "ERROR: cannot find dataset '$dataset' in datasetList.text"
+  echo "ERROR: cannot find dataset '$dataset' in datasetList.txt"
   exit 100
 fi
 

--- a/qa-physics/datasetOrganize.sh
+++ b/qa-physics/datasetOrganize.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [ $# -ne 1 ];then echo "USAGE: $0 [dataset]"; exit; fi
 dataset=$1
 
@@ -13,8 +15,7 @@ for outdir in outmon outdat; do
 done
 
 # loop over runs, copying and linking to dataset subdirs
-runL=$(grep $dataset datasetList.txt | awk '{print $2}')
-runH=$(grep $dataset datasetList.txt | awk '{print $3}')
+source datasetListParser.sh $dataset
 for file in outmon/monitor_*.hipo; do
   run=$(echo $file | sed 's/^.*monitor_//'|sed 's/\.hipo$//')
 

--- a/qa-physics/exeSlurm.sh
+++ b/qa-physics/exeSlurm.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [ -z "$CLASQA" ]; then
   echo "ERROR: please source env.sh first"
   exit
@@ -17,14 +19,7 @@ if [ $# -eq 2 ]; then usetape=1; fi
 echo "dataset=$dataset"
 echo "usetape=$usetape"
 
-
-runL=$(grep $dataset datasetList.txt | awk '{print $2}')
-runH=$(grep $dataset datasetList.txt | awk '{print $3}')
-datadir=$(grep $dataset datasetList.txt | awk '{print $4}')
-if [ -z "$datadir" ]; then
-  echo "ERROR: dataset not foundin datasetList.txt"
-  exit
-fi
+source datasetListParser.sh $dataset
 
 if [ $usetape -eq 1 ]; then
   datadir=$(echo $datadir | sed 's/^\/cache/\/mss/g')

--- a/qa-physics/getListOfDSTs.sh
+++ b/qa-physics/getListOfDSTs.sh
@@ -3,6 +3,8 @@
 # - this script may take a while to run
 # - use the output for integrityCheck.sh
 
+set -e
+
 if [ -z "$CLASQA" ]; then
   echo "ERROR: please source env.sh first"
   exit
@@ -11,11 +13,7 @@ fi
 if [ $# -ne 1 ];then echo "USAGE: $0 [dataset]"; exit; fi
 dataset=$1
 
-datadir=$(grep $dataset datasetList.txt | awk '{print $4}')
-if [ -z "$datadir" ]; then
-  echo "ERROR: dataset not foundin datasetList.txt"
-  exit
-fi
+source datasetListParser.sh $dataset
 datadir=$(echo $datadir | sed 's/^\/cache/\/mss/g')
 echo "datadir=$datadir"
 ls $datadir


### PR DESCRIPTION
- fixes a bug where a `dataset` name is found more than once in `datasetList.txt`, causing parsing issues (even when the string appears in a comment)
- centralizes `datasetList.txt` parsing in a sourceable script