### PR TITLE
fix: error printouts should stream to `stderr`

### DIFF
--- a/bin/qa.sh
+++ b/bin/qa.sh
@@ -27,7 +27,7 @@ if [ $# -lt 1 ]; then
 
     -t DIRECTORY
          set TIMELINEDIR to specified directory
-  """
+  """ >&2
   exit 101
 fi
 

--- a/bin/slurm-mon12.sh
+++ b/bin/slurm-mon12.sh
@@ -5,10 +5,10 @@ BINDIR="`dirname $0`"
 MONDIR="`realpath $BINDIR/..`"
 JARPATH="$MONDIR/monitoring/target/clas12-monitoring-v0.0-alpha.jar"
 
-[[ ! -f $JARPATH ]] && echo "---- [ERROR] Problem with jar file for clas12_monitoring package --------" && echo && exit 100
+[[ ! -f $JARPATH ]] && echo "---- [ERROR] Problem with jar file for clas12_monitoring package --------" >&2 && echo && exit 100
 
 # test if there is a version name
-echo $1 | grep -q "/" && echo "---- [ERROR] version name must not contain / -------" && echo && exit 100
+echo $1 | grep -q "/" && echo "---- [ERROR] version name must not contain / -------" >&2 && echo && exit 100
 
 ver=$1
 shift

--- a/detectors/src/main/java/org/jlab/clas/timeline/run.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/run.groovy
@@ -169,13 +169,13 @@ if(eng) {
 
       println("debug: "+engine.getClass().getSimpleName()+" finished $arg")
     } catch(Exception ex) {
-      println("error: "+engine.getClass().getSimpleName()+" didn't process $arg")
+      System.err.println("error: "+engine.getClass().getSimpleName()+" didn't process $arg")
       System.exit(100)
     }
   }
   engine.close()
   println("debug: "+engine.getClass().getSimpleName()+" ended")
 } else {
-  println("error: "+args[0]+" not found")
+  System.err.println("error: "+args[0]+" not found")
   System.exit(100)
 }

--- a/detectors/src/main/java/org/jlab/clas/timeline/run_rgb.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/run_rgb.groovy
@@ -171,13 +171,13 @@ if(eng) {
 
       println("debug: "+engine.getClass().getSimpleName()+" finished $arg")
     } catch(Exception ex) {
-      println("error: "+engine.getClass().getSimpleName()+" didn't process $arg")
+      System.err.println("error: "+engine.getClass().getSimpleName()+" didn't process $arg")
       System.exit(100)
     }
   }
   engine.close()
   println("debug: "+engine.getClass().getSimpleName()+" ended")
 } else {
-  println("error: "+args[0]+" not found")
+  System.err.println("error: "+args[0]+" not found")
   System.exit(100)
 }

--- a/qa-detectors/util/applyBounds.groovy
+++ b/qa-detectors/util/applyBounds.groovy
@@ -21,7 +21,7 @@ def cutsFileList = [
 /////////////////////////////////////////////////////
 
 // parse arguments
-if(args.length<1) { println "ERROR: specify dataset name"; System.exit(100); }
+if(args.length<1) { System.err.println "ERROR: specify dataset name"; System.exit(100); }
 def dataset = args[0]
 
 // get www dir, by searching datasetList.txt for specified `dataset`, and set

--- a/qa-physics/QA/import.sh
+++ b/qa-physics/QA/import.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 # copy qaTree.json from ../outdat.$dataset, so we can start the QA
 if [ $# -lt 1 ]; then
-  echo "USAGE: $0 [dataset] [optional: path to qaTree.json] [optional: options for parseQaTree.groovy]"
-  echo ""
-  echo "- to see parseQaTree options: $0 [dataset] -h"
-  echo "                         and: $0 [dataset] -l"
-  echo ""
-  echo "- for manual QA: $0 [dataset] -cnds=user_comment"
+  echo """
+  USAGE: $0 [dataset] [optional: path to qaTree.json] [optional: options for parseQaTree.groovy]
+
+  - to see parseQaTree options: $0 [dataset] -h
+                           and: $0 [dataset] -l
+
+  - for manual QA: $0 [dataset] -cnds=user_comment
+  """ >&2
   exit 101
 fi
 dataset=$1

--- a/qa-physics/QA/modifyQaTree.groovy
+++ b/qa-physics/QA/modifyQaTree.groovy
@@ -21,13 +21,13 @@ println("\n\n")
 def cmd
 if(args.length>=1) cmd = args[0]
 else { 
-  println(
+  System.err.println(
   """
   syntax: modify.sh [command] [arguments]\n
 List of Commands:
   """)
-  usage.each{ println("- "+it.value) }
-  println("\ntype any command without arguments for usage for that command\n")
+  usage.each{ System.err.println("- "+it.value) }
+  System.err.println("\ntype any command without arguments for usage for that command\n")
   System.exit(101)
 }
 
@@ -113,7 +113,7 @@ if( cmd=="setBit" || cmd=="addBit" || cmd=="delBit") {
   }
   else {
     def helpStr = usage["$cmd"].tokenize(':')[1]
-    println(
+    System.err.println(
     """
     SYNTAX: ${cmd} [defectBit] [run] [firstFile] [lastFile] [list_of_sectors]
       -$helpStr
@@ -121,9 +121,9 @@ if( cmd=="setBit" || cmd=="addBit" || cmd=="delBit") {
       - use \"all\" in place of [list_of_sectors] to apply to all sectors
       - you will be prompted to enter a comment
     """)
-    println("Bit List:\n")
+    System.err.println("Bit List:\n")
     T.bitDefinitions.size().times {
-      println("$it\t" + T.bitNames[it] + "\t" + T.bitDescripts[it] + "\n")
+      System.err.println("$it\t" + T.bitNames[it] + "\t" + T.bitDescripts[it] + "\n")
     }
     System.exit(101)
   }
@@ -166,7 +166,7 @@ else if(cmd=="sectorLoss") {
   }
   else {
     def helpStr = usage["$cmd"].tokenize(':')[1]
-    println(
+    System.err.println(
     """
     SYNTAX: ${cmd} [run] [firstFile] [lastFile] [list_of_sectors]
       -$helpStr
@@ -214,7 +214,7 @@ else if( cmd=="addComment" || cmd=="setComment") {
     }
   }
   else {
-    println(
+    System.err.println(
     """
     SYNTAX: ${cmd} [run] [firstFile] [lastFile]
       - set [lastFile] to 1 to denote last file of run
@@ -278,7 +278,7 @@ else if( cmd=="custom") {
 }
 
 
-else { println("ERROR: unknown command!"); System.exit(100) }
+else { System.err.println("ERROR: unknown command!"); System.exit(100) }
 
 
 // update qaTree.json

--- a/qa-physics/QA/parseQaTree.groovy
+++ b/qa-physics/QA/parseQaTree.groovy
@@ -19,11 +19,11 @@ def outfileW = outfileF.newWriter(false)
 
 // Print out help message
 if(args.contains("-h") || args.contains("--help")) { 
-  println("Options:")
-  println(" -l/--list               : List available conditions from db")
-  println(" -cnds=cnd1,cnd2,...     : Set commands to output table (default: 'user_comment')")
-  println(" -addCnds=cnd1,cnd2,...  : Add commands to output table")
-  println(" -h/--help               : Print this message")
+  System.err.println("Options:")
+  System.err.println(" -l/--list               : List available conditions from db")
+  System.err.println(" -cnds=cnd1,cnd2,...     : Set commands to output table (default: 'user_comment')")
+  System.err.println(" -addCnds=cnd1,cnd2,...  : Add commands to output table")
+  System.err.println(" -h/--help               : Print this message")
   System.exit(101)
 }
 

--- a/qa-physics/Tools.groovy
+++ b/qa-physics/Tools.groovy
@@ -29,7 +29,7 @@ class Tools {
     def bitNum = bitNames.findIndexOf{ it==bitName }
     if(bitNum>=0 && bitNum<bitNames.size()) return bitNum
     else {
-      System.err << "ERROR bad bit name $bitName\n"
+      System.err.println "ERROR bad bit name $bitName"
       return 31
     }
   }

--- a/qa-physics/datasetListParser.sh
+++ b/qa-physics/datasetListParser.sh
@@ -6,14 +6,14 @@
 # usage: `source $0 $dataset`
 
 if [ $# -ne 1 ]; then
-  echo "ERROR: dataset not specified"
+  echo "ERROR: dataset not specified" >&2
   exit 100
 fi
 
 line=$(grep -wE "^$dataset" datasetList.txt | tail -n1)
 
 if [ -z "$line" ]; then
-  echo "ERROR: cannot find dataset '$dataset' in datasetList.txt"
+  echo "ERROR: cannot find dataset '$dataset' in datasetList.txt" >&2
   exit 100
 fi
 

--- a/qa-physics/datasetOrganize.sh
+++ b/qa-physics/datasetOrganize.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ $# -ne 1 ];then echo "USAGE: $0 [dataset]"; exit 101; fi
+if [ $# -ne 1 ];then echo "USAGE: $0 [dataset]" >&2; exit 101; fi
 dataset=$1
 
 # cleanup / generate new dataset subdirs

--- a/qa-physics/deployTimelines.sh
+++ b/qa-physics/deployTimelines.sh
@@ -3,11 +3,11 @@
 # - must be run on ifarm
 
 if [ $# -ne 2 ]; then
-  echo "usage: $0 [dataset] [destinationName]"
+  echo "usage: $0 [dataset] [destinationName]" >&2
   exit 101
 fi
 if [ -z "$CLASQA" ]; then
-  echo "ERROR: please source env.sh first"
+  echo "ERROR: please source env.sh first" >&2
   exit 100
 fi
 

--- a/qa-physics/exeQAtimelines.sh
+++ b/qa-physics/exeQAtimelines.sh
@@ -5,7 +5,7 @@
 if [ -z "$CLASQA" ]; then source env.sh; fi
 
 if [ $# -ne 1 ]; then
-  echo "USAGE: $0 [dataset]"
+  echo "USAGE: $0 [dataset]" >&2
   exit 101
 fi
 dataset=$1

--- a/qa-physics/exeSlurm.sh
+++ b/qa-physics/exeSlurm.sh
@@ -3,14 +3,16 @@
 set -e
 
 if [ -z "$CLASQA" ]; then
-  echo "ERROR: please source env.sh first"
+  echo "ERROR: please source env.sh first" >&2
   exit 100
 fi
 
 if [ $# -lt 1 ]; then
-  echo "USAGE: $0 [dataset]"
-  echo "optional: if you specify a second argument, it will use files from tape"
-  echo "          (warning: this feature has never been tested, and needs development!)"
+  echo """
+  USAGE: $0 [dataset]
+  optional: if you specify a second argument, it will use files from tape
+            (warning: this feature has never been tested, and needs development!)
+  """ >&2
   exit 101
 fi
 dataset=$1

--- a/qa-physics/exeTimelines.sh
+++ b/qa-physics/exeTimelines.sh
@@ -2,7 +2,7 @@
 
 if [ -z "$CLASQA" ]; then source env.sh; fi
 
-if [ $# -ne 1 ];then echo "USAGE: $0 [dataset]"; exit 101; fi
+if [ $# -ne 1 ];then echo "USAGE: $0 [dataset]" >&2; exit 101; fi
 dataset=$1
 
 # setup error filtered execution function

--- a/qa-physics/getListOfDSTs.sh
+++ b/qa-physics/getListOfDSTs.sh
@@ -6,11 +6,11 @@
 set -e
 
 if [ -z "$CLASQA" ]; then
-  echo "ERROR: please source env.sh first"
+  echo "ERROR: please source env.sh first" >&2
   exit 100
 fi
 
-if [ $# -ne 1 ];then echo "USAGE: $0 [dataset]"; exit 101; fi
+if [ $# -ne 1 ];then echo "USAGE: $0 [dataset]" >&2; exit 101; fi
 dataset=$1
 
 source datasetListParser.sh $dataset

--- a/qa-physics/integrityCheck.sh
+++ b/qa-physics/integrityCheck.sh
@@ -6,22 +6,22 @@
 # - must run getListOfDSTs.sh first
 
 if [ -z "$CLASQA" ]; then
-  echo "ERROR: please source env.sh first"
+  echo "ERROR: please source env.sh first" >&2
   exit 100
 fi
 
-if [ $# -ne 1 ];then echo "USAGE: $0 [dataset]"; exit 101; fi
+if [ $# -ne 1 ];then echo "USAGE: $0 [dataset]" >&2; exit 101; fi
 dataset=$1
 
 if [ ! -f dstlist.${dataset}.dat ]; then
-  echo "ERROR: dstlist.${dataset}.dat does not exist"
-  echo "execute getListOfDSTs.sh first"
+  echo "ERROR: dstlist.${dataset}.dat does not exist" >&2
+  echo "execute getListOfDSTs.sh first" >&2
   exit 100
 fi
 
 if [ ! -f outdat.${dataset}/data_table.dat ]; then
-  echo "ERROR: outdat.${dataset}/data_table.dat does not exist"
-  echo "execute exeTimelines.sh first"
+  echo "ERROR: outdat.${dataset}/data_table.dat does not exist" >&2
+  echo "execute exeTimelines.sh first" >&2
   exit 100
 fi
 

--- a/qa-physics/jcacheRun.sh
+++ b/qa-physics/jcacheRun.sh
@@ -2,7 +2,7 @@
 # jcache a directory of DST files
 
 if [ $# -ne 1 ]; then
-  echo "USAGE $0 [cache directory of DST stubs]"
+  echo "USAGE $0 [cache directory of DST stubs]" >&2
   exit 101
 fi
 cachedir=$1

--- a/qa-physics/jprint.groovy
+++ b/qa-physics/jprint.groovy
@@ -1,6 +1,6 @@
 if(args.size()==0) {
-  println("\n\nARGUMENTS: jsonfile [tree-path]")
-  println("""
+  System.err.println("\n\nARGUMENTS: jsonfile [tree-path]")
+  System.err.println("""
   pretty prints a json file
   - if it is a nested map (tree), specify additional arguments
     to restrict printout to a specific sub-tree

--- a/qa-physics/mkTree.sh
+++ b/qa-physics/mkTree.sh
@@ -3,7 +3,7 @@
 
 if [ $# -eq 1 ]; then dataset=$1
 else
-  echo "USAGE: $0 [dataset]"
+  echo "USAGE: $0 [dataset]" >&2
   exit 101
 fi
 

--- a/qa-physics/monitorRead.groovy
+++ b/qa-physics/monitorRead.groovy
@@ -40,13 +40,13 @@ if(inHipoType=="dst") {
   }
   inHipoList.sort()
   if(inHipoList.size()==0) {
-    System.err << "ERROR: no hipo files found in this directory\n"
+    System.err.println "ERROR: no hipo files found in this directory"
     System.exit(100)
   }
 }
 else if(inHipoType=="skim") { inHipoList << inHipo }
 else {
-  System.err << "ERROR: unknown inHipoType setting\n"
+  System.err.println "ERROR: unknown inHipoType setting"
   System.exit(100)
 }
 
@@ -80,7 +80,7 @@ else if(runnum>=11093 && runnum<=11300) RG="RGB" // fall 19
 else if(runnum>=11323 && runnum<=11571) RG="RGB" // winter 20
 else if(runnum>=12210 && runnum<=12951) RG="RGF" // spring+summer 20
 else if(runnum>=15019 && runnum<=15884) RG="RGM" 
-else System.err << "WARNING: unknown run group; using default run-group-dependent settings (see monitorRead.groovy)\n"
+else System.err.println "WARNING: unknown run group; using default run-group-dependent settings (see monitorRead.groovy)"
 println "rungroup = $RG"
 
 // helFlip: if true, REC::Event.helicity has opposite sign from reality
@@ -108,25 +108,25 @@ else if(RG=="RGB") {
   else if(runnum>=11093 && runnum<=11283) EBEAM = 10.4096 // fall
   else if(runnum>=11284 && runnum<=11300) EBEAM = 4.17179 // fall BAND_FT
   else if(runnum>=11323 && runnum<=11571) EBEAM = 10.3894 // winter (RCDB may still be incorrect)
-  else System.err << "ERROR: unknown beam energy\n"
+  else System.err.println "ERROR: unknown beam energy"
 }
 else if(RG=="RGK") {
   if(runnum>=5674 && runnum<=5870) EBEAM = 7.546
   else if(runnum>=5875 && runnum<=6000) EBEAM = 6.535
-  else System.err << "ERROR: unknown beam energy\n"
+  else System.err.println "ERROR: unknown beam energy"
 }
 else if(RG=="RGF") {
   if     (runnum>=12210 && runnum<=12388) EBEAM = 10.389 // RCDB may still be incorrect
   else if(runnum>=12389 && runnum<=12443) EBEAM =  2.186 // RCDB may still be incorrect
   else if(runnum>=12444 && runnum<=12951) EBEAM = 10.389 // RCDB may still be incorrect
-  else System.err << "ERROR: unknown beam energy\n"
+  else System.err.println "ERROR: unknown beam energy"
 }
 else if(RG=="RGM") {
   if     (runnum>=15013 && runnum<=15490) EBEAM = 5.98636 
   else if(runnum>=15533 && runnum<=15727) EBEAM = 2.07052 
   else if(runnum>=15728 && runnum<=15784) EBEAM = 4.02962 
   else if(runnum>=15787 && runnum<=15884) EBEAM = 5.98636 
-  else System.err << "ERROR: unknown beam energy\n"
+  else System.err.println "ERROR: unknown beam energy"
 }
 
 /* gated FC charge determination: `FCmode`
@@ -364,7 +364,7 @@ def countTriggerElectrons = { eleRows,eleParts ->
           }
 
         } else {
-          System.err << "WARNING: found electron with unknown sector\n"
+          System.err.println "WARNING: found electron with unknown sector"
         }
       }
 
@@ -433,7 +433,7 @@ def countTriggerElectrons = { eleRows,eleParts ->
 
     // - increment counters, and set `disEleFound`
     if(disElectronInTrigger && disElectronInFT) { // can never happen (failsafe)
-      System.err << "ERROR: disElectronInTrigger && disElectronInFT == 1; skip event\n"
+      System.err.println "ERROR: disElectronInTrigger && disElectronInFT == 1; skip event"
       return
     }
     else if(disElectronInTrigger) {
@@ -570,7 +570,7 @@ def writeHistos = {
       ufcStart = UFClist.min()
       ufcStop = UFClist.max()
     } else {
-      System.err << "WARNING: empty UFClist for run=${runnum} file=${segmentNum}\n"
+      System.err.println "WARNING: empty UFClist for run=${runnum} file=${segmentNum}"
       ufcStart = 0
       ufcStop = 0
     }
@@ -587,14 +587,13 @@ def writeHistos = {
         fcStart = FClist.min()
         fcStop = FClist.max()
       } else {
-        System.err << "WARNING: empty FClist for run=${runnum} file=${segmentNum}\n"
+        System.err.println "WARNING: empty FClist for run=${runnum} file=${segmentNum}"
         fcStart = 0
         fcStop = 0
       }
     }
     if(fcStart>fcStop || ufcStart>ufcStop) {
-      System.err << "WARNING: faraday cup start > stop for" <<
-        " run=${runnum} file=${segmentNum}\n"
+      System.err.println "WARNING: faraday cup start > stop for run=${runnum} file=${segmentNum}"
     }
 
     // RGB attenuation correction
@@ -625,8 +624,8 @@ def writeHistos = {
     */
   }
   else {
-    System.err << "WARNING: empty segment (segmentTmp=$segmentTmp)\n"
-    System.err << " if all segments in a run are empty, there will be more errors later!"
+    System.err.println "WARNING: empty segment (segmentTmp=$segmentTmp)"
+    System.err.println " if all segments in a run are empty, there will be more errors later!"
   }
 
   // reset number of trigger electrons counter and FC lists

--- a/qa-physics/qaCut.groovy
+++ b/qa-physics/qaCut.groovy
@@ -28,7 +28,7 @@ def jPrint = { name,object -> new File(name).write(JsonOutput.toJson(object)) }
 // read epochs list file
 def epochFile = new File("epochs/epochs.${dataset}.txt")
 if(!(epochFile.exists())) {
-  System.err << "WARNING: using epochs/epochs.default.txt\n"
+  System.err.println "WARNING: using epochs/epochs.default.txt"
   epochFile = new File("epochs/epochs.default.txt")
 }
 
@@ -144,7 +144,7 @@ inList.each { obj ->
 // subroutine for calculating median of a list
 def median = { d ->
   if(d.size()==0) {
-    System.err << "WARNING: attempt to calculate median of an empty list\n"
+    System.err.println "WARNING: attempt to calculate median of an empty list"
     return -10000
   }
   d.sort()

--- a/qa-physics/releaseTimelines.sh
+++ b/qa-physics/releaseTimelines.sh
@@ -2,11 +2,11 @@
 # copy a locally deployed timeline to the release directory
 
 if [ $# -ne 1 ]; then 
-  echo "USAGE: $0 [dataset]"
+  echo "USAGE: $0 [dataset]" >&2
   exit 101
 fi
 if [ -z "$CLASQA" ]; then
-  echo "ERROR: please source env.sh first"
+  echo "ERROR: please source env.sh first" >&2
   exit 100
 fi
 


### PR DESCRIPTION
To allow for errors to be more easily seen in log files, redirect them to `stderr`.