### PR TITLE
fix(qa-physics): generate Slurm jobs from specified directory, not tape stubs directory

### DIFF
--- a/qa-physics/exeSlurm.sh
+++ b/qa-physics/exeSlurm.sh
@@ -54,6 +54,11 @@ checkIfCached() {
   fi
 }
 
+# get a list of run subdirectories
+getRunDirs() {
+  echo $(ls -d $1/*/ | sed 's;/$;;')
+}
+
 
 # preparation
 # -----------------------------------------------------------------------
@@ -78,16 +83,14 @@ mkdir -p tmp
 echo "#!/bin/bash" > $jcacheList
 
 # check if DATADIR is a /cache subdirectory; if so, we will loop through the
-# corresponding tape stub directory, cross checking with the /cache directory,
-# but the data will be read from the /cache directory
+# corresponding tape stub directory, cross checking with the /cache directory
 isCacheDir=0
-dataDirMain=$DATADIR
 if [[ "$DATADIR" =~ "/cache/" ]]; then
   isCacheDir=1
   dataDirCache=$DATADIR
   dataDirTape=$(cache2tape $DATADIR)
-  dataDirMain=$dataDirTape 
-  # diff the cache and tape stub directories, to see if one has runs that the other does not
+
+  # diff the cache and tape stub top-level directories, to see if one has runs that the other does not
   ls $dataDirCache | grep -vi readme > tmp/cacheList
   ls $dataDirTape | grep -vi readme > tmp/tapeList
   diff -y --suppress-common-lines tmp/{cache,tape}List > tmp/diffList
@@ -104,14 +107,20 @@ $(cat tmp/diffList)
 
     """
   fi
+
+  # then diff each run subdirectory
+  for runDir in `getRunDirs $dataDirTape`; do
+    checkIfCached $(tape2cache $runDirTape) $runDirTape
+  done
+
 fi
 
 
-# build job commands
+# build job commands, only for the runs in specified range
 # -----------------------------------------------------------------------
 joblist=slurm/joblist.${dataset}.slurm
 > $joblist
-for runDir in `ls -d ${dataDirMain}/*/ | sed 's;/$;;'`; do
+for runDir in `getRunDirs $DATADIR`; do
 
   # get the run number, and check if it's in range
   runnum=$((10#$(echo $runDir | sed 's;.*/;;g')))
@@ -119,18 +128,8 @@ for runDir in `ls -d ${dataDirMain}/*/ | sed 's;/$;;'`; do
   if [ $runnum -ge $RUNL -a $runnum -le $RUNH ]; then
     echo "--- found"
 
-    # if reading from cache, compare with tape stubs
-    runDirRead=$runDir
-    if [ $isCacheDir -eq 1 ]; then
-      runDirTape=$runDir
-      runDirCache=$(tape2cache $runDirTape)
-      checkIfCached $runDirCache $runDirTape
-      runDirRead=$runDirCache
-    fi
-    cmd="run-groovy $CLASQA_JAVA_OPTS monitorRead.groovy $runDirRead dst"
-
     # append the command to the joblist
-    echo "$cmd" >> $joblist
+    echo "run-groovy $CLASQA_JAVA_OPTS monitorRead.groovy $runDir dst" >> $joblist
 
     # move old output files to a trash directory
     for runfile in outdat/data_table_${runnum}.dat outmon/monitor_${runnum}.hipo; do

--- a/qa-physics/exeSlurm.sh
+++ b/qa-physics/exeSlurm.sh
@@ -110,7 +110,8 @@ $(cat tmp/diffList)
 
   # then diff each run subdirectory
   for runDir in `getRunDirs $dataDirTape`; do
-    checkIfCached $(tape2cache $runDirTape) $runDirTape
+    echo "Checking if cached: $runDir"
+    checkIfCached $(tape2cache $runDir) $runDir
   done
 
 fi


### PR DESCRIPTION
### problem
https://github.com/JeffersonLab/clas12-timeline/pull/72 introduced a bug where if one specifies a `/cache` directory, and the files are not (yet) on tape, the job list will not be populated.

### solution
This PR resolves the issue by generating jobs from `/cache`, not `/mss`.

@esteejus