### PR TITLE
build: use Java 11 for `monitoring/`

### DIFF
--- a/monitoring/pom.xml
+++ b/monitoring/pom.xml
@@ -17,6 +17,7 @@
   <packaging>jar</packaging>
 
   <build>
+
     <extensions>
       <extension>
         <groupId>org.apache.maven.wagon</groupId>
@@ -24,6 +25,18 @@
         <version>2.8</version>
       </extension>
     </extensions>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+        <configuration>
+          <release>11</release>
+        </configuration>
+      </plugin>
+    </plugins>
+
   </build>
 
 </project>


### PR DESCRIPTION
This allows us to use features such as [type inference](https://openjdk.org/jeps/286).