### PR TITLE
fix: do not backup previous detector timelines

### DIFF
--- a/bin/run-detectors-timelines.sh
+++ b/bin/run-detectors-timelines.sh
@@ -165,10 +165,7 @@ detDirs=(
 # cleanup output directories
 if ${modes['focus-all']} || ${modes['focus-timelines']}; then
   if [ -d $finalDirPreQA ]; then
-    backupDir=$(pwd -P)/tmp/backup.$dataset.$(date +%s) # use unixtime for uniqueness
-    echo ">>> backing up any previous files to $backupDir ..."
-    mkdir -p $backupDir/
-    mv -v $finalDirPreQA $backupDir/
+    rm -rv $finalDirPreQA
   fi
 fi
 if [ -d $logDir ]; then


### PR DESCRIPTION
Backing up produced timelines can cause unnecessary and rapid disk space consumption during routine online timeline production (viz. RG-D); so let's just remove them.

Backups from `run-monitoring.sh` may remain and still be useful, since these backups are not created in SWIF running.