### PR TITLE
hotfix: use `run_rgb.groovy` for RG-D, to include BAND timelines

### DIFF
--- a/bin/run-detectors-timelines.sh
+++ b/bin/run-detectors-timelines.sh
@@ -84,7 +84,7 @@ export CLASSPATH="$JYPATH${CLASSPATH:+:${CLASSPATH}}"
 # get main executable for detector timelines
 # FIXME: remove run group dependence
 MAIN="org.jlab.clas.timeline.run"
-if [[ "$rungroup" == "b" ]]; then
+if [ "$rungroup" = "b" -o "$rungroup" = "d" ]; then
   MAIN="org.jlab.clas.timeline.run_rgb"
 fi
 [[ ! "$rungroup" =~ ^[a-zA-Z] ]] && printError "unknown rungroup '$rungroup'" && exit 100

--- a/detectors/src/main/java/org/jlab/clas/timeline/run.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/run.groovy
@@ -31,9 +31,6 @@ def engines = [
     new cvt.cvt_d0_mean_pos(),
     new cvt.cvt_d0_sigma_pos(),
     new cvt.cvt_d0_max_pos(),
-//    new cvt.cvt_d0_mean_neg(),
-//    new cvt.cvt_d0_sigma_neg(),
-//    new cvt.cvt_d0_max_neg(),
     new trigger.rat_Km_num(),
     new trigger.rat_neg_num(),
     new trigger.rat_pos_num(),
@@ -52,11 +49,9 @@ def engines = [
     new forward.forward_Tracking_NegVz(),
     new ec.ec_Sampl(),
     new ec.ec_gg_m(),
-	new ec.ec_pcal_time(),
-	new ec.ec_ecin_time(),
-	new ec.ec_ecou_time(),
-//    new ec.ec_pip_time(),
-//    new ec.ec_pim_time(),
+    new ec.ec_pcal_time(),
+    new ec.ec_ecin_time(),
+    new ec.ec_ecou_time(),
     new ltcc.ltcc_nphe_sector(),
     new rf.rftime_diff(),
     new rf.rftime_pim_FD(),
@@ -73,7 +68,6 @@ def engines = [
     new cnd.cnd_zdiff()],
   out_CTOF: [new ctof.ctof_edep(),
     new ctof.ctof_time(),
-    // new ctof.ctof_tdcadc(),
     new ctof.ctof_tdcadc_left(),
     new ctof.ctof_tdcadc_right()],
   out_FT: [new ft.ftc_pi0_mass(),
@@ -99,9 +93,9 @@ def engines = [
     new ftof.ftof_edep_p2(),
     new ftof.ftof_time_p1a(),
     new ftof.ftof_time_p1b(),
+    new ftof.ftof_time_p2(),
     new ftof.ftof_time_noTriggers_p1a(),
     new ftof.ftof_time_noTriggers_p1b(),
-    new ftof.ftof_time_p2(),
     new ftof.ftof_tdcadc_p1a(),
     new ftof.ftof_tdcadc_p1b(),
     new ftof.ftof_tdcadc_p2(),
@@ -140,7 +134,6 @@ if(args.any{it=="--timelines"}) {
   }
   System.exit(0)
 }
-
 
 def eng = engines.collectMany{key,engs->engs.collect{[key,it]}}
   .find{name,eng->eng.getClass().getSimpleName()==args[0]}

--- a/detectors/src/main/java/org/jlab/clas/timeline/run_rgb.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/run_rgb.groovy
@@ -112,7 +112,7 @@ def engines = [
     new dc.dc_residuals_sec_sl_rescut(),
     new dc.dc_t0_sec_sl(),
     new dc.dc_t0_even_sec_sl(),
-    new dc.dc_t0_odd_sec_sl(),        
+    new dc.dc_t0_odd_sec_sl(),
     new dc.dc_tmax_sec_sl()],
   out_RICH: [new rich.rich_dt_m(), 
        new rich.rich_trk_m(), 


### PR DESCRIPTION
BAND is not included in RG-D timelines, since it uses the default `run.groovy` set. This hotfix will use RG-B's `run_rgb.groovy` script for RG-D so that BAND is visible.

Makes https://github.com/JeffersonLab/clas12-timeline/issues/74 worse, but seeing BAND timelines is a higher priority.