### PR TITLE
fix: `run-detectors-timelines.sh` skips every 8th timeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
           - detectors
           - physics
         include:
-          - { type: detectors,  args: -n 2 -r B } # FIXME: prefer `-r ${{env.validation_run_group}}`, but that's invalid syntax for matrix arg
+          - { type: detectors,  args: -n 2 -r B --skip-mya } # FIXME: prefer `-r ${{env.validation_run_group}}`, but that's invalid syntax for matrix arg
           - { type: physics,    args: '' }
     steps:
     - name: setup java

--- a/bin/run-detectors-timelines.sh
+++ b/bin/run-detectors-timelines.sh
@@ -12,7 +12,7 @@ rungroup=a
 numThreads=8
 singleTimeline=""
 declare -A modes
-for key in list build focus-timelines focus-qa; do
+for key in list build skip-mya focus-timelines focus-qa; do
   modes[$key]=false
 done
 
@@ -52,6 +52,8 @@ if [ $# -eq 0 ]; then
 
     --build             cleanly-rebuild the timeline code, then run
 
+    --skip-mya          skip timelines which require MYA (needed if running offsite or on CI)
+
     --focus-timelines   only produce the detector timelines, do not run detector QA code
     --focus-qa          only run the QA code (assumes you have detector timelines already)
   """ >&2
@@ -90,12 +92,19 @@ fi
 [[ ! "$rungroup" =~ ^[a-zA-Z] ]] && printError "unknown rungroup '$rungroup'" && exit 100
 export MAIN
 
+# build list of timelines
+if ${modes['skip-mya']}; then
+  timelineList=$(java $MAIN --timelines | grep -vE '^epics_')
+else
+  timelineList=$(java $MAIN --timelines)
+fi
+
 # list detector timelines, if requested
 if ${modes['list']}; then
   echo $sep
   echo "LIST OF TIMELINES"
   echo $sep
-  java $MAIN --timelines
+  echo $timelineList | sed 's; ;\n;g'
   exit $?
 fi
 
@@ -192,7 +201,7 @@ if ${modes['focus-all']} || ${modes['focus-timelines']}; then
 
   # produce timelines, multithreaded
   jobCnt=1
-  for timelineObj in $(java $MAIN --timelines); do
+  for timelineObj in $timelineList; do
     logFile=$logDir/$timelineObj
     [ -n "$singleTimeline" -a "$timelineObj" != "$singleTimeline" ] && continue
     echo ">>> producing timeline '$timelineObj' ..."

--- a/bin/run-detectors-timelines.sh
+++ b/bin/run-detectors-timelines.sh
@@ -195,9 +195,9 @@ if ${modes['focus-all']} || ${modes['focus-timelines']}; then
   for timelineObj in $(java $MAIN --timelines); do
     logFile=$logDir/$timelineObj
     [ -n "$singleTimeline" -a "$timelineObj" != "$singleTimeline" ] && continue
-    if [ $jobCnt -le $numThreads ]; then
-      echo ">>> producing timeline '$timelineObj' ..."
-      java $TIMELINE_JAVA_OPTS $MAIN $timelineObj $inputDir > $logFile.out 2> $logFile.err || touch $logFile.fail &
+    echo ">>> producing timeline '$timelineObj' ..."
+    java $TIMELINE_JAVA_OPTS $MAIN $timelineObj $inputDir > $logFile.out 2> $logFile.err || touch $logFile.fail &
+    if [ $jobCnt -lt $numThreads ]; then
       let jobCnt++
     else
       wait

--- a/detectors/src/main/java/org/jlab/clas/timeline/timeline/epics/epics_xy.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/timeline/epics/epics_xy.groovy
@@ -26,9 +26,6 @@ class epics_xy {
     def (t0str, t1str) = [t0, t1].collect{DateUtilExtensions.format(it, "yyyy-MM-dd")}
 
     def epics = [:].withDefault{[:]}
-    System.err.println("DEBUG: https://epicsweb.jlab.org/myquery/interval?c=IPM2H01.XPOS&b=$t0str&e=$t1str&l=&t=eventsimple&m=history&f=3&v=&d=on&p=on")
-    System.err.println("DEBUG: https://epicsweb.jlab.org/myquery/interval?c=IPM2H01.YPOS&b=$t0str&e=$t1str&l=&t=eventsimple&m=history&f=3&v=&d=on&p=on")
-    System.err.println("DEBUG: https://epicsweb.jlab.org/myquery/interval?c=IPM2H01&b=$t0str&e=$t1str&l=&t=eventsimple&m=history&f=3&v=&d=on&p=on")
     def xs = REST.get("https://epicsweb.jlab.org/myquery/interval?c=IPM2H01.XPOS&b=$t0str&e=$t1str&l=&t=eventsimple&m=history&f=3&v=&d=on&p=on").data
       .each{epics[new SimpleDateFormat('yyyy-MM-dd HH:mm:ss.SSS').parse(it.d).getTime()].x = it.v}
     def ys = REST.get("https://epicsweb.jlab.org/myquery/interval?c=IPM2H01.YPOS&b=$t0str&e=$t1str&l=&t=eventsimple&m=history&f=3&v=&d=on&p=on").data

--- a/detectors/src/main/java/org/jlab/clas/timeline/timeline/epics/epics_xy.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/timeline/epics/epics_xy.groovy
@@ -26,6 +26,9 @@ class epics_xy {
     def (t0str, t1str) = [t0, t1].collect{DateUtilExtensions.format(it, "yyyy-MM-dd")}
 
     def epics = [:].withDefault{[:]}
+    System.err.println("DEBUG: https://epicsweb.jlab.org/myquery/interval?c=IPM2H01.XPOS&b=$t0str&e=$t1str&l=&t=eventsimple&m=history&f=3&v=&d=on&p=on")
+    System.err.println("DEBUG: https://epicsweb.jlab.org/myquery/interval?c=IPM2H01.YPOS&b=$t0str&e=$t1str&l=&t=eventsimple&m=history&f=3&v=&d=on&p=on")
+    System.err.println("DEBUG: https://epicsweb.jlab.org/myquery/interval?c=IPM2H01&b=$t0str&e=$t1str&l=&t=eventsimple&m=history&f=3&v=&d=on&p=on")
     def xs = REST.get("https://epicsweb.jlab.org/myquery/interval?c=IPM2H01.XPOS&b=$t0str&e=$t1str&l=&t=eventsimple&m=history&f=3&v=&d=on&p=on").data
       .each{epics[new SimpleDateFormat('yyyy-MM-dd HH:mm:ss.SSS').parse(it.d).getTime()].x = it.v}
     def ys = REST.get("https://epicsweb.jlab.org/myquery/interval?c=IPM2H01.YPOS&b=$t0str&e=$t1str&l=&t=eventsimple&m=history&f=3&v=&d=on&p=on").data


### PR DESCRIPTION
The number '8' comes from the default number of threads used for this script. This fix should bring back the missing ECAL SF timeline for @forcar.