### PR TITLE
fix: stabilize FTOF p1b vertex time fits

### DIFF
--- a/detectors/src/main/java/org/jlab/clas/timeline/fitter/FTOFFitter.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/fitter/FTOFFitter.groovy
@@ -5,37 +5,13 @@ import org.jlab.groot.math.F1D
 
 
 class FTOFFitter {
-	static F1D timefit_p1a(H1F h1) {
-		def f1 = new F1D("fit:"+h1.getName(), "[amp]*gaus(x,[mean],[sigma])", -1.0, 1.0);
-		double hAmp  = h1.getBinContent(h1.getMaximumBin());
-		double hMean = h1.getAxis().getBinCenter(h1.getMaximumBin());
-		double hRMS  = h1.getRMS(); //ns
-		f1.setRange(hMean-2.5*hRMS, hMean+2.5*hRMS);
-		f1.setParameter(0, hAmp);
-		f1.setParameter(1, hMean);
-		f1.setParameter(2, Math.min(hRMS,0.1));
 
-		def makefit = {func->
-		  hMean = func.getParameter(1)
-		  hRMS = func.getParameter(2).abs()
-		  func.setRange(hMean-2*hRMS,hMean+2*hRMS)
-		  MoreFitter.fit(func,h1,"Q")
-		  return [func.getChiSquare(), (0..<func.getNPars()).collect{func.getParameter(it)}]
-		}
-
-		def fits1 = (0..20).collect{makefit(f1)}
-		def bestfit = fits1.sort()[0]
-		f1.setParameters(*bestfit[1])
-		//makefit(f1)
-		return f1
-	}
-
-  static F1D timefit_p1b(H1F h1) {
+  static F1D timefit_p1(H1F h1) {
     def f1 = new F1D("fit:"+h1.getName(), "[amp]*gaus(x,[mean],[sigma])", -1.0, 1.0);
     double hAmp  = h1.getBinContent(h1.getMaximumBin());
-    double hMean = 0 //h1.getAxis().getBinCenter(h1.getMaximumBin());
+    double hMean = h1.getAxis().getBinCenter(h1.getMaximumBin());
     double hRMS  = Math.min(h1.getRMS(),0.05); //ns
-    f1.setRange(hMean-1.5*hRMS, hMean+1.5*hRMS);
+    f1.setRange(hMean-2.0*hRMS, hMean+2.0*hRMS);
     f1.setParameter(0, hAmp);
     f1.setParameter(1, hMean);
     f1.setParameter(2, hRMS);
@@ -43,7 +19,7 @@ class FTOFFitter {
     def makefit = {func->
       hMean = func.getParameter(1)
       hRMS = func.getParameter(2).abs()
-      func.setRange(hMean-1.5*hRMS,hMean+1.5*hRMS)
+      func.setRange(hMean-2.0*hRMS,hMean+2.0*hRMS)
       MoreFitter.fit(func,h1,"Q")
       return [func.getChiSquare(), (0..<func.getNPars()).collect{func.getParameter(it)}]
     }

--- a/detectors/src/main/java/org/jlab/clas/timeline/timeline/ftof/ftof_time_noTriggers_p1a.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/timeline/ftof/ftof_time_noTriggers_p1a.groovy
@@ -15,7 +15,7 @@ def processDirectory(dir, run) {
   def chi2list = []
   def histlist =   (0..<6).collect{
     def h1 = dir.getObject('/tof/p1a_dt_notriggertrack_S'+(it+1))
-    def f1 = FTOFFitter.timefit_p1a(h1)
+    def f1 = FTOFFitter.timefit_p1(h1)
 
     funclist.add(f1)
     meanlist.add(f1.getParameter(1))

--- a/detectors/src/main/java/org/jlab/clas/timeline/timeline/ftof/ftof_time_noTriggers_p1b.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/timeline/ftof/ftof_time_noTriggers_p1b.groovy
@@ -17,7 +17,7 @@ def processDirectory(dir, run) {
   def sigmaerrorlist = []
   def histlist =   (0..<6).collect{
     def h1 = dir.getObject('/tof/p1b_dt_notriggertrack_S'+(it+1))
-    def f1 = FTOFFitter.timefit_p1b(h1)
+    def f1 = FTOFFitter.timefit_p1(h1)
 
     funclist.add(f1)
     meanlist.add(f1.getParameter(1))

--- a/detectors/src/main/java/org/jlab/clas/timeline/timeline/ftof/ftof_time_p1a.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/timeline/ftof/ftof_time_p1a.groovy
@@ -17,7 +17,7 @@ def processDirectory(dir, run) {
   def sigmaerrorlist = []
   def histlist =   (0..<6).collect{
     def h1 = dir.getObject('/tof/p1a_dt_S'+(it+1))
-    def f1 = FTOFFitter.timefit_p1a(h1)
+    def f1 = FTOFFitter.timefit_p1(h1)
 
     funclist.add(f1)
     meanlist.add(f1.getParameter(1))

--- a/detectors/src/main/java/org/jlab/clas/timeline/timeline/ftof/ftof_time_p1b.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/timeline/ftof/ftof_time_p1b.groovy
@@ -17,7 +17,7 @@ def processDirectory(dir, run) {
   def sigmaerrorlist = []
   def histlist =   (0..<6).collect{
     def h1 = dir.getObject('/tof/p1b_dt_S'+(it+1))
-    def f1 = FTOFFitter.timefit_p1b(h1)
+    def f1 = FTOFFitter.timefit_p1(h1)
 
     funclist.add(f1)
     meanlist.add(f1.getParameter(1))


### PR DESCRIPTION
FTOF p1b vertex time timeline for RG-D after 18607 have bad fits. This PR makes p1a and p1b use the same fit method, with compromising initial fit parameters.

This should be tested on the full RG-D timeline.