### PR TITLE
fix: stalled fit in `ec_ecou_time`

### DIFF
--- a/detectors/src/main/java/org/jlab/clas/timeline/fitter/ECFitter.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/fitter/ECFitter.groovy
@@ -40,7 +40,7 @@ class ECFitter {
     double hRMS  = h1.getRMS(); //ns
     f1.setParameter(0, hAmp);
     f1.setParameter(1, hMean);
-    f1.setParameter(2, 0.1);
+    f1.setParameter(2, hRMS);
     f1.setRange(hMean-1,hMean+1)
     DataFitter.fit(f1,h1,"")
 


### PR DESCRIPTION
RG-C run 16907 fit hangs and throws no errors. This PR attempts to fix the issue by using a variable RMS for the initial fit parameter, instead of a fixed and very small guess.