### PR TITLE
fix(qa-detectors): catch TABs in `cuts.txt` parser

### DIFF
--- a/qa-detectors/cuts/cuts.txt
+++ b/qa-detectors/cuts/cuts.txt
@@ -4,7 +4,7 @@ rf   rftime_electron_FD_sigma    0      0.070  ns
 ltcc ltcc_elec_nphe_sec          11     14     counts sec3
 ltcc ltcc_elec_nphe_sec          11     14     counts sec5
 
-htcc htcc_nphe_sec	         12.5   14.5   counts
+htcc htcc_nphe_sec               12.5   14.5   counts
 htcc htcc_vtimediff_sector_mean  -1     1      ns
 htcc htcc_vtimediff_sector_sigma 0      1      ns
 

--- a/qa-detectors/cuts/cuts.txt
+++ b/qa-detectors/cuts/cuts.txt
@@ -4,7 +4,7 @@ rf   rftime_electron_FD_sigma    0      0.070  ns
 ltcc ltcc_elec_nphe_sec          11     14     counts sec3
 ltcc ltcc_elec_nphe_sec          11     14     counts sec5
 
-htcc htcc_nphe_sec               12.5   14.5   counts
+htcc htcc_nphe_sec	         12.5   14.5   counts
 htcc htcc_vtimediff_sector_mean  -1     1      ns
 htcc htcc_vtimediff_sector_sigma 0      1      ns
 

--- a/qa-detectors/util/applyBounds.groovy
+++ b/qa-detectors/util/applyBounds.groovy
@@ -67,7 +67,12 @@ cutsFileList.each { re, cutsFile ->
       // tokenize
       line = line.replaceAll(/#.*/,'')
       tok = line.tokenize(' ')
-      if(tok.size()==0) return
+      if(tok.size()==0)
+        return
+      if(tok =~ /\t/) {
+        System.err.println "ERROR: $cutsFileName contains a TAB, please replace them with SPACEs"
+        System.exit(100)
+      }
       def det      = tok[0]
       def timeline = tok[1]
       def lbound   = tok[2].toDouble()


### PR DESCRIPTION
The parser's tokenization uses SPACEs as its delimiter, so TABs will be a part of the tokens. This PR throws an error if a TAB is detected in a token, and informs the user to replace TABs with SPACEs.