### PR TITLE
fix: print run number as integer in `dump-timelines.groovy`

### DIFF
--- a/bin/dump-timelines.groovy
+++ b/bin/dump-timelines.groovy
@@ -87,7 +87,7 @@ inFiles.each{ inFile ->
     if(it==0) {
       outFileWriter << "#runnum " << tlGraphs.collect{gr->"'${gr.getName()}'"}.join(' ') << '\n'
     }
-    outFileWriter << runnum << ' '
+    outFileWriter << runnum.toInteger() << ' '
     tlGraphs.each{ gr ->
       if(runnum != gr.getDataX(it)) {
         System.err.println("ERROR: timelines have differing run numbers")


### PR DESCRIPTION
Fix for @hauenst 