### PR TITLE
perf: reduce the number of physics-QA plots

### DIFF
--- a/qa-physics/README.md
+++ b/qa-physics/README.md
@@ -115,8 +115,7 @@ First step is to read DST or Skim files, producing HIPO files and data tables
   * reads data table and generates `monitorElec.hipo`
     * within this HIPO file, there is one directory for each run, containing several
       plots:
-      * `grA*`: N/F vs. time bin (the `A` notation is so it appears first in the
-        online timeline front-end)
+      * `grA*`: N/F vs. time bin
       * `grF*`: F vs. time bin
       * `grN*`: N vs. time bin
       * `grT*`: livetime vs. time bin

--- a/qa-physics/qaCut.groovy
+++ b/qa-physics/qaCut.groovy
@@ -339,22 +339,36 @@ def addEpochPlotPoint = { plotOut,plotIn,i,r ->
   def n = r + f/5000.0 // "bin index"
   plotOut.addPoint(n,plotIn.getDataY(i),0,0)
 }
-def writeHipo = { hipo,outList -> outList.each{ hipo.addDataSet(it) } }
-def addGraphsToHipo = { hipoFile ->
+def writeHipo = { hipo,outList ->
+  outList.each{ hipo.addDataSet(it) }
+}
+def prioGraph = { g, prio ->
+  prioStr = prio < 10 ? "0$prio" : "$prio"
+  g.setName("p${prioStr}_${g.getName()}")
+}
+def addGraphsToHipo = { hipoFile, sectorNum ->
   hipoFile.mkdir("/${runnum}")
   hipoFile.cd("/${runnum}")
-  writeHipo(
-    hipoFile,
-    [
-      grA_good,grA_bad,
-      grN_good,grN_bad,
-      grF_good,grF_bad,
-      grU_good,grU_bad,
-      grT_good,grT_bad,
-      histA_good,histA_bad,
-      lineMedian, lineCutLo, lineCutHi
+  // organize graphs for the front-end (they will render in alphabetical order, so prefix them with p#)
+  [grA_good, grA_bad, lineMedian, lineCutLo, lineCutHi].each{prioGraph(it, 2*sectorNum-1)}
+  [grN_good, grN_bad].each{prioGraph(it, 2*sectorNum)}
+  [grF_good, grF_bad].each{prioGraph(it, 2*6+1)}
+  [grU_good, grU_bad].each{prioGraph(it, 2*6+2)}
+  [grT_good, grT_bad].each{prioGraph(it, 2*6+3)}
+  // list of graphs to include on the front-end
+  writeList = [
+    grA_good, grA_bad,
+    grN_good, grN_bad,
+    lineMedian, lineCutLo, lineCutHi
+  ]
+  if(sectorNum == 1) {
+    writeList += [
+      grF_good, grF_bad,
+      grU_good, grU_bad,
+      grT_good, grT_bad,
     ]
-  )
+  }
+  writeHipo(hipoFile, writeList)
 }
 
 
@@ -628,17 +642,17 @@ inList.each { obj ->
         grA,lowerBound,upperBound,"cutHi",cutTree[sector][epoch]['cutHi'])
 
       // write graphs to hipo file
-      addGraphsToHipo(outHipoQA)
-      addGraphsToHipo(outHipoA)
-      addGraphsToHipo(outHipoN)
-      addGraphsToHipo(outHipoU)
-      addGraphsToHipo(outHipoF)
-      addGraphsToHipo(outHipoFA)
-      addGraphsToHipo(outHipoLTT)
-      addGraphsToHipo(outHipoLTA)
-      addGraphsToHipo(outHipoSigmaN)
-      addGraphsToHipo(outHipoSigmaF)
-      addGraphsToHipo(outHipoRhoNF)
+      addGraphsToHipo(outHipoQA, sector)
+      addGraphsToHipo(outHipoA, sector)
+      addGraphsToHipo(outHipoN, sector)
+      addGraphsToHipo(outHipoU, sector)
+      addGraphsToHipo(outHipoF, sector)
+      addGraphsToHipo(outHipoFA, sector)
+      addGraphsToHipo(outHipoLTT, sector)
+      addGraphsToHipo(outHipoLTA, sector)
+      addGraphsToHipo(outHipoSigmaN, sector)
+      addGraphsToHipo(outHipoSigmaF, sector)
+      addGraphsToHipo(outHipoRhoNF, sector)
 
       // fill timeline points
       nGood = grA_good.getDataSize(0)

--- a/qa-physics/qaPlot.groovy
+++ b/qa-physics/qaPlot.groovy
@@ -34,10 +34,10 @@ def trigRat
 def errPrint = { str -> System.err << "ERROR in run ${runnum}_${binnum}: "+str+"\n" }
 
 // define graphs
-def defineGraph = { name,ytitle ->
+def defineGraph = { name, ytitle, sectorDependent ->
   sectors.collect {
     def g = new GraphErrors(name+"_${runnum}_"+sec(it))
-    def gT = ytitle+" vs. time bin"+(useFT?"":" -- Sector "+sec(it))
+    def gT = ytitle+" vs. time bin" + ((sectorDependent && !useFT) ? " -- Sector ${sec(it)}" : "")
     g.setTitle(gT)
     g.setTitleY(ytitle)
     g.setTitleX("time bin")
@@ -98,11 +98,11 @@ dataFile.eachLine { line ->
   // if the run number changed, write filled graphs, then start new graphs
   if(runnum!=runnumTmp) {
     if(runnumTmp>0) writePlots(runnumTmp)
-    grA = defineGraph("grA","${electronT} Normalized Yield N/F")
-    grN = defineGraph("grN","${electronT} Yield N")
-    grF = defineGraph("grF","Gated Faraday Cup charge F [nC]")
-    grU = defineGraph("grU","Ungated Faraday Cup charge F [nC]")
-    grT = defineGraph("grT","Live Time")
+    grA = defineGraph("grA", "${electronT} Normalized Yield N/F", true)
+    grN = defineGraph("grN", "${electronT} Yield N", true)
+    grF = defineGraph("grF", "Gated Faraday Cup charge F [nC]", false)
+    grU = defineGraph("grU", "Ungated Faraday Cup charge F [nC]", false)
+    grT = defineGraph("grT", "Live Time", false)
     runnumTmp = runnum
   }
 


### PR DESCRIPTION
- gated and ungated FC charge and livetime are not sector dependent -> draw only one plot, rather than duplicating them 6 times
- remove the N/F histograms since they are not useful
- organize the plots better

This cuts the plots by more than half, and this will be useful with fine time bins, which take a while to load on slower computers.