### PR TITLE
feat(physics): timeline for FC charge non-monotonicity

### DIFF
--- a/qa-physics/monitorPlot.groovy
+++ b/qa-physics/monitorPlot.groovy
@@ -401,7 +401,7 @@ inList.each { inFile ->
     //--------------------------
     if(objN.contains("/nonMonotonicity_")) {
       varStr = tok[1]
-      T.addLeaf(monTree,[runnum,'charge',varStr,'valGraph',{obj})
+      T.addLeaf(monTree,[runnum,'charge',varStr,'valGraph'],{obj})
     }
 
   } // eo loop over objects in the file (run)

--- a/qa-physics/monitorPlot.groovy
+++ b/qa-physics/monitorPlot.groovy
@@ -515,7 +515,7 @@ T.exeLeaves(monTree,{
       def tot    = vals.size()
       def ave    = tot>0 ? vals.sum() / tot : 0
       def devs   = vals.collect{ (it-ave)**2 }
-      def stddev = Math.sqrt( devs.sum() / tot )
+      def stddev = tot>0 ? Math.sqrt( devs.sum() / tot ) : tot
       T.getLeaf(timelineTree,tlPath+'timeline').addPoint(tlRun,ave,0.0,0.0)
       if(tlPath.contains('DIS') || tlPath.contains('inclusive') || tlPath.contains('nonMonotonicity')) {
         T.getLeaf(timelineTree,tlPath+'timelineDev').addPoint(tlRun,stddev,0.0,0.0)

--- a/qa-physics/monitorPlot.groovy
+++ b/qa-physics/monitorPlot.groovy
@@ -400,8 +400,7 @@ inList.each { inFile ->
     // charge non-monotonicicity
     //--------------------------
     if(objN.contains("/nonMonotonicity_")) {
-      varStr = tok[1]
-      T.addLeaf(monTree,[runnum,'charge',varStr,'valGraph'],{obj})
+      T.addLeaf(monTree,[runnum,'charge','nonMonotonicity','valGraph'],{obj})
     }
 
   } // eo loop over objects in the file (run)
@@ -466,7 +465,10 @@ T.exeLeaves(monTree,{
         if(tlPath.contains('pip')) tlT = "inclusive pi+ kinematics"
         if(tlPath.contains('pim')) tlT = "inclusive pi- kinematics"
       }
-      if(tlPath.contains('nonMonotonicity')) tlT = "FC charge non-monotonicity"
+      if(tlPath.contains('nonMonotonicity')) {
+        tlT = "FC charge non-monotonicity"
+        tlN = "mean_non-monotonicity"
+      }
       if(T.key.contains('Dist')) tlT = "average ${tlT}"
       tlT = "${tlT} vs. run number"
       def tl = new GraphErrors(tlN)
@@ -484,7 +486,10 @@ T.exeLeaves(monTree,{
           if(tlPath.contains('pip')) tlT = "inclusive pi+ kinematics"
           if(tlPath.contains('pim')) tlT = "inclusive pi- kinematics"
         }
-        if(tlPath.contains('nonMonotonicity')) tlT = "FC charge non-monotonicity"
+        if(tlPath.contains('nonMonotonicity')) {
+          tlT = "FC charge non-monotonicity"
+          tlN = "stddev_non-monotonicicity"
+        }
         if(T.key.contains('Dist')) tlT = "standard deviation of ${tlT}"
         tlT = "${tlT} vs. run number"
         def tl = new GraphErrors(tlN)
@@ -551,7 +556,7 @@ def checkFilter( list, filter, keyName="" ) {
          !keyName.contains("Numer") && !keyName.contains("Denom")
 }
 
-def hipoWrite = { hipoName, filterList, TLkey ->
+def hipoWrite = { hipoName, filterList, TLkeys ->
   def outHipo = new TDirectory()
   monTree.each { run,tree ->
     outHipo.mkdir("/${run}")
@@ -575,7 +580,7 @@ def hipoWrite = { hipoName, filterList, TLkey ->
   outHipo.mkdir("/timelines")
   outHipo.cd("/timelines")
   T.exeLeaves(timelineTree,{
-    if(checkFilter(T.leafPath,filterList) && T.key==TLkey) {
+    if(checkFilter(T.leafPath,filterList) && TLkeys.contains(T.key)) {
       outHipo.addDataSet(T.leaf)
     }
   })
@@ -587,16 +592,17 @@ def hipoWrite = { hipoName, filterList, TLkey ->
 }
 
 // write objects to hipo files
-hipoWrite("helicity_sinPhi",['helic','sinPhi'],"timeline")
-hipoWrite("beam_spin_asymmetry",['helic','asym'],"timeline")
-hipoWrite("defined_helicity_fraction",['helic','dist','heldef'],"timeline")
-hipoWrite("relative_yield",['helic','dist','rellum'],"timeline")
-hipoWrite("q2_W_x_y_means",['DIS'],"timeline")
-hipoWrite("pip_kinematics_means",['inclusive','pip'],"timeline")
-hipoWrite("pim_kinematics_means",['inclusive','pim'],"timeline")
-hipoWrite("q2_W_x_y_stddevs",['DIS'],"timelineDev")
-hipoWrite("pip_kinematics_stddevs",['inclusive','pip'],"timelineDev")
-hipoWrite("pim_kinematics_stddevs",['inclusive','pim'],"timelineDev")
+hipoWrite("helicity_sinPhi",['helic','sinPhi'],["timeline"])
+hipoWrite("beam_spin_asymmetry",['helic','asym'],["timeline"])
+hipoWrite("defined_helicity_fraction",['helic','dist','heldef'],["timeline"])
+hipoWrite("relative_yield",['helic','dist','rellum'],["timeline"])
+hipoWrite("q2_W_x_y_means",['DIS'],["timeline"])
+hipoWrite("pip_kinematics_means",['inclusive','pip'],["timeline"])
+hipoWrite("pim_kinematics_means",['inclusive','pim'],["timeline"])
+hipoWrite("q2_W_x_y_stddevs",['DIS'],["timelineDev"])
+hipoWrite("pip_kinematics_stddevs",['inclusive','pip'],["timelineDev"])
+hipoWrite("pim_kinematics_stddevs",['inclusive','pim'],["timelineDev"])
+hipoWrite("faraday_cup_charge_non-monotonicity",['charge','nonMonotonicity'],["timeline","timelineDev"])
 
 // sort qaTree and output to json file
 qaTree.each { qaRun, qaRunTree -> qaRunTree.sort{it.key.toInteger()} }

--- a/qa-physics/monitorRead.groovy
+++ b/qa-physics/monitorRead.groovy
@@ -949,7 +949,7 @@ timeBins.each{ itBinNum, itBin ->
   printDebug "  ungated: (lb,ub)   = [${ufc_lb}, ${ufc_ub}]"
   printDebug "           (min,max) = [${ufc_min}, ${ufc_max}]"
   def chargeViaBounds = fc_ub  - fc_lb
-  def chargeViaMinMax = fx_max - fc_min
+  def chargeViaMinMax = fc_max - fc_min
   // not clear whether `chargeViaBounds` or `chargeViaMinMax` is the real charge, so we calculate their percent difference w.r.t. their mean:
   def ave = (chargeViaBounds + chargeViaMinMax) / 2.0
   def nonMonotonicity = ave==0 ? 0 : Math.abs(chargeViaBounds - chargeViaMinMax) / ave

--- a/qa-physics/monitorRead.groovy
+++ b/qa-physics/monitorRead.groovy
@@ -7,6 +7,7 @@ import org.jlab.io.hipo.HipoDataSource
 import org.jlab.clas.physics.Particle
 import org.jlab.groot.data.H1F
 import org.jlab.groot.data.H2F
+import org.jlab.groot.data.GraphErrors
 import org.jlab.groot.data.TDirectory
 import org.jlab.clas.physics.LorentzVector
 import org.jlab.detector.base.DetectorType
@@ -934,6 +935,8 @@ is a bit non-monotonic, looking like
 If the bin boundary is on one of these non-monotonic jumps, the min or max FC charge within a bin
 may be smaller or larger than the FC charge values at the bin boundaries
 */
+def nonMonotonicityGr = new GraphErrors("nonMonotonicity_${runnum}_0") // one graph for all time bins, so just set time bin number to `0`
+nonMonotonicityGr.setTitle("FC charge non-monotonicity vs. time bin")
 timeBins.each{ itBinNum, itBin ->
   if(itBinNum+1 == timeBins.size()) return // can't cross check the last bin
   def (fc_lb,   fc_ub)   = itBin.fcRange
@@ -945,18 +948,14 @@ timeBins.each{ itBinNum, itBin ->
   printDebug "           (min,max) = [${fc_min}, ${fc_max}]"
   printDebug "  ungated: (lb,ub)   = [${ufc_lb}, ${ufc_ub}]"
   printDebug "           (min,max) = [${ufc_min}, ${ufc_max}]"
-  def problems = []
-  def calculate_amount = { lb, ub, val -> Math.abs(val) / (ub-lb) }
-  if(fc_min < fc_lb) { problems << [ "minimum gated", "less", "${fc_min} < ${fc_lb}", calculate_amount(fc_lb, fc_ub, fc_min-fc_lb) ] }
-  if(fc_max > fc_ub) { problems << [ "maximum gated", "more", "${fc_max} > ${fc_ub}", calculate_amount(fc_lb, fc_ub, fc_max-fc_ub) ] }
-  if(ufc_min < ufc_lb) { problems << [ "minimum ungated", "less", "${ufc_min} < ${ufc_lb}", calculate_amount(ufc_lb, ufc_ub, ufc_min-ufc_lb) ] }
-  if(ufc_max > ufc_ub) { problems << [ "maximum ungated", "more", "${ufc_max} > ${ufc_ub}", calculate_amount(ufc_lb, ufc_ub, ufc_max-ufc_ub) ] }
-  problems.each{
-    // TODO: these "off by" amounts should go in a dedicated timeline; until then, pester the user with these errors
-    // System.err.println "WARNING: ${it[0]} FC charge is ${it[1]} than that at bin boundary, for bin number ${itBinNum}  (${it[2]}); off by ${100.0*it[3]}%"
-  }
+  def chargeViaBounds = fc_ub  - fc_lb
+  def chargeViaMinMax = fx_max - fc_min
+  // not clear whether `chargeViaBounds` or `chargeViaMinMax` is the real charge, so we calculate their percent difference w.r.t. their mean:
+  def ave = (chargeViaBounds + chargeViaMinMax) / 2.0
+  def nonMonotonicity = ave==0 ? 0 : Math.abs(chargeViaBounds - chargeViaMinMax) / ave
+  nonMonotonicityGr.addPoint(itBinNum, nonMonotonicity, 0.0, 0.0)
 }
-
+outHipo.addDataSet(nonMonotonicityGr)
 
 // close output text files
 datfileWriter.flush()


### PR DESCRIPTION
The bin-by-bin FC charge calculated via the difference of the values at the bin boundaries is very slightly different from the charge calculated by the bin's max charge minus the min charge. This difference is because the FC charge vs. timestamp is slightly non-monotonic for data prior to RG-C. While the effect is expected to be very small, we add a timeline to make sure that it is.