### PR TITLE
Update to htcc npheAll timeline's title and y axis

### DIFF
--- a/detectors/src/main/java/org/jlab/clas/timeline/timeline/htcc/htcc_npheAll.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/timeline/htcc/htcc_npheAll.groovy
@@ -24,7 +24,7 @@ class htcc_npheAll {
     out.mkdir('/timelines')
     // (0..<6).each{ sec->
     def grtl = new GraphErrors('htcc_npheAll_mean')
-    grtl.setTitle("Mean NPHE Across All Channels per Run")
+    grtl.setTitle("Mean NPHE Combined Across All Channels per Run")
     grtl.setTitleY("Mean NPHE")
     grtl.setTitleX("Run Number")
 

--- a/detectors/src/main/java/org/jlab/clas/timeline/timeline/htcc/htcc_npheAll.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/timeline/htcc/htcc_npheAll.groovy
@@ -24,9 +24,9 @@ class htcc_npheAll {
     out.mkdir('/timelines')
     // (0..<6).each{ sec->
     def grtl = new GraphErrors('htcc_npheAll_mean')
-    grtl.setTitle("Mean Combined HTCC timing")
-    grtl.setTitleY("Mean Combined HTCC timing (ns)")
-    grtl.setTitleX("run number")
+    grtl.setTitle("Mean NPHE Across All Channels per Run")
+    grtl.setTitleY("Mean NPHE")
+    grtl.setTitleX("Run Number")
 
     data.sort{it.key}.each{run,it->
       out.mkdir('/'+it.run)


### PR DESCRIPTION
Previous title and y axis labels incorrectly labelled this plot for timing
Has been updated to correctly display that info in plot is from mean nphe combined across channels per run