### PR TITLE
fix: slurm script names should include `$dataset` for uniqueness

### DIFF
--- a/bin/run-monitoring.sh
+++ b/bin/run-monitoring.sh
@@ -343,7 +343,7 @@ for rdir in ${rdirs[@]}; do
     mkdir -p $outputSubDir
 
     # make job scripts for each $key
-    jobscript=$slurmDir/scripts/$key.$runnum.sh
+    jobscript=$slurmDir/scripts/$key.$dataset.$runnum.sh
     case $key in
 
       detectors)


### PR DESCRIPTION
This prevents them from being clobbered if we want to process the same run number but with different dataset names.