### PR TITLE
fix: handle missing CVT efficiency data

### DIFF
--- a/detectors/src/main/java/org/jlab/clas/timeline/timeline/cvt/cvt_efficiency.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/timeline/cvt/cvt_efficiency.groovy
@@ -53,6 +53,12 @@ def close() {
     grtl.addPoint(it.run, it.eff, 0, 0)
   }
 
+  // if there are no points, we need to add at least one bogus point, otherwise the front-end will hang
+  if(grtl.getDataSize(0) == 0) {
+    grtl.addPoint(0, 0, 0, 0)
+    grtl.setTitle("${grtl.getTitle()}: ERROR - efficiency table has not yet been generated for these runs")
+  }
+
   out.mkdir('/timelines')
   out.cd('/timelines')
   grtl.each{ out.addDataSet(it) }


### PR DESCRIPTION
If CVT efficiency data have not yet been generated for all runs in a dataset's run range, add a point at `(0,0)` on the timeline so that the front-end does not hang. The plot title is also modified to inform the viewer.