### PR TITLE
fix: require non-empty `ftof_ctof_vtdiff` histograms before fit attempt

### DIFF
--- a/detectors/src/main/java/org/jlab/clas/timeline/timeline/ftof/ftof_ctof_vtdiff.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/timeline/ftof/ftof_ctof_vtdiff.groovy
@@ -11,9 +11,10 @@ def data = new ConcurrentHashMap()
 def processDirectory(dir, run) {
   (1..6).collect{sec->
     def h1 = dir.getObject("/tof/ftof-ctof_vtdiff_S${sec}")
-    def f1 = MoreFitter.fitgaus(h1)
-
-    data.computeIfAbsent(sec, {[]}).add([run:run, h1:h1, f1:f1, mean:f1.getParameter(1), sigma:f1.getParameter(2).abs()])
+    if(h1.integral() > 0.0) {
+      def f1 = MoreFitter.fitgaus(h1)
+      data.computeIfAbsent(sec, {[]}).add([run:run, h1:h1, f1:f1, mean:f1.getParameter(1), sigma:f1.getParameter(2).abs()])
+    }
   }
 }
 


### PR DESCRIPTION
Issue caused by #233 and identified by #234.

With this PR, we are safe to update the xrootd validation files.