### PR TITLE
fix: `rich_dt_m` sigma bounds and timeout bad fits

### DIFF
--- a/detectors/src/main/java/org/jlab/clas/timeline/fitter/RICHFitter.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/fitter/RICHFitter.groovy
@@ -2,6 +2,8 @@ package org.jlab.clas.timeline.fitter
 import org.jlab.groot.fitter.DataFitter
 import org.jlab.groot.data.H1F
 import org.jlab.groot.math.F1D
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.CompletableFuture
 
 
 class RICHFitter {
@@ -10,21 +12,46 @@ class RICHFitter {
     def hAmp  = h1.getBinContent(h1.getMaximumBin());
     def hMean = h1.getAxis().getBinCenter(h1.getMaximumBin())
     def hRMS = Math.min(h1.getRMS(),0.44)
+    def h1range = h1.getDataX(h1.getDataSize(0)-1) - h1.getDataX(0)
 
     f1.setParameter(0, hAmp)
     f1.setParameter(1, hMean)
     f1.setParameter(2, hRMS)
+    f1.setParLimits(2, 0, h1range) // don't let sigma be < 0
     f1.setParameter(3, 0)
+
+    def fitTimedOut = false
 
     def makefits = {func->
       hRMS = func.getParameter(2).abs()
       func.setRange(hMean-3.0*hRMS, hMean+3.0*hRMS)
-      DataFitter.fit(func,h1,"Q")
+
+      // try the fit, but don't try for too long...
+      if(!fitTimedOut) {
+        def out = System.out
+        def err = System.err
+        def fut = CompletableFuture.runAsync{DataFitter.fit(func,h1,"Q")}
+        try {
+          fut.get(10, TimeUnit.SECONDS) // 10 second timeout
+        } catch(def ex) {
+          System.setOut(out)
+          System.setErr(err)
+          err.println("FIT timeout")
+          fitTimedOut = true
+        }
+      }
+
+      // give up, if timed out
+      if(fitTimedOut) {
+        func.getNPars().times{func.setParameter(it, 0.0)}
+      }
+
       return [func.getChiSquare(), (0..<func.getNPars()).collect{func.getParameter(it)}]
     }
     def fits1 = (0..10).collect{makefits(f1)}
 
     def f2 = new F1D("fit:"+h1.getName(), "[amp]*gaus(x,[mean],[sigma])+[p0]+[p1]*x+[p2]*x*x",-0.2,0.2);
+    f2.setParLimits(2, 0, h1range) // don't let sigma be < 0
 
     fits1.sort()[0][1].eachWithIndex{par,ipar->
       f2.setParameter(ipar, par)
@@ -34,6 +61,12 @@ class RICHFitter {
 
     def bestfit = fits2.sort()[0]
     f2.setParameters(*bestfit[1])
+
+    // if the fit timed out, set the mean and sigma to an obviously bad value
+    if(fitTimedOut) {
+      f2.setParameter(1, 10 * h1range)
+      f2.setParameter(2, 10 * h1range)
+    }
 
     return f2
   }


### PR DESCRIPTION
RG-D run 18355 was stalling, because of a bad fit. I found that setting the lower bound of `sigma` helps make this fit converge. I also added a timeout to the fit routine, which will abort the fit after 10 seconds.

However, it seems that RG-D's fits are quite bad for this timeline, but that's a problem for another PR.