### PR TITLE
fix(build): use `maven` for dependency `org.apache.commons`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "org.apache.commons:commons-csv" # FIXME: `monitorRead.groovy` is not yet compatible with later versions of this dependency
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/bin/run-monitoring.sh
+++ b/bin/run-monitoring.sh
@@ -430,6 +430,9 @@ echo "RUN $runnum"
 # set classpath
 export JYPATH=$JYPATH
 
+# additional env vars
+export TIMELINESRC=$TIMELINESRC
+
 # produce histograms
 run-groovy \\
   $TIMELINE_GROOVY_OPTS \\

--- a/detectors/pom.xml
+++ b/detectors/pom.xml
@@ -43,6 +43,31 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+        <!--
+          make sure some dependencies are installed in the local build directory, so they are
+          picked up in the `run-groovy` classpath; use configuration parameter `includeArtifactIds`
+          to copy ONLY the ones we actually need to be copied
+        -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.8.1</version>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <includeArtifactIds>commons-csv</includeArtifactIds> <!-- need only these deps copied -->
+              <outputDirectory>${project.build.directory}</outputDirectory>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
@@ -65,6 +90,12 @@
       <groupId>org.apache.groovy</groupId>
       <artifactId>groovy-dateutil</artifactId>
       <version>4.0.25</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-csv -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-csv</artifactId>
+      <version>1.2</version> <!-- FIXME: `monitorRead.groovy` is not yet compatible with later versions of this dependency -->
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.codehaus.gpars/gpars -->
     <dependency>

--- a/qa-physics/monitorRead.groovy
+++ b/qa-physics/monitorRead.groovy
@@ -13,7 +13,6 @@ import org.jlab.clas.physics.LorentzVector
 import org.jlab.detector.base.DetectorType
 import java.lang.Math.*
 import org.jlab.clas.timeline.util.Tools
-@Grab('org.apache.commons:commons-csv:1.2')
 import org.apache.commons.csv.CSVParser
 import static org.apache.commons.csv.CSVFormat.*
 import java.nio.file.Paths
@@ -224,6 +223,10 @@ if (FCmode==3) {
 
   // Check if CSV file exists
   def TIMELINESRC = System.getenv("TIMELINESRC")
+  if(TIMELINESRC == null) {
+    System.err.println "ERROR: \$TIMELINESRC is not set"
+    System.exit(100)
+  }
   csvfilepath = Paths.get(TIMELINESRC, '/data/fccharge/'+RG+'.csv').toAbsolutePath().toString()
   def csvfile = new File(csvfilepath)
   if (csvfile.exists()) {


### PR DESCRIPTION
- ~allows @dependabot to keep it up-to-date~ yes, but for now we need to keep it at 1.2 (see #267)
- fixes #265 by moving the dependency resolution from runtime to build-time