### PR TITLE
fix: do not calculate beam charge asymmetry for RG-D

### DIFF
--- a/qa-physics/monitorRead.groovy
+++ b/qa-physics/monitorRead.groovy
@@ -801,7 +801,8 @@ inHipoList.each { inHipoFile ->
       default: helDefined = false; helicity = 0; break
     }
     // get scaler helicity from `HEL::scaler`, and fill its charge-weighted distribution
-    if(hipoEvent.hasBank("HEL::scaler")) {
+    // NOTE: do not do this if FCmode==3 (since FC charge is wrong)
+    if(hipoEvent.hasBank("HEL::scaler") && FCmode!=3) {
       helScalerBank.rows().times{ row -> // HEL::scaler readouts "pile up", so there are multiple bank rows in an event
         def sc_helicity = helScalerBank.getByte("helicity", row)
         def sc_fc       = helScalerBank.getFloat("fcupgated", row) // helicity-latched FC charge


### PR DESCRIPTION
Since the FC charge is wrong for RG-D, we don't want to produce the beam charge asymmetry timeline.
- do not fill the helicity-latched FC charge-weighted helicity distribution
- beam charge asymmetry timeline should therefore be empty
- corresponding HIPO file will be trashed