### PR TITLE
fix: OutOfMemoryError from `buildChargeTree.groovy`

### DIFF
--- a/qa-physics/buildChargeTree.groovy
+++ b/qa-physics/buildChargeTree.groovy
@@ -79,7 +79,7 @@ runTree.each { runnum, binnums ->
   // add helicity-latched charge for each bin
   binnums.each { binnum ->
     def histName = "helic_scaler_chargeWeighted_" + runnum + "_" + binnum
-    hist = (H1F)inMdir.getObject(runnum + "/",histName);
+    def hist = (H1F)inMdir.getObject(runnum + "/",histName);
     def helicityCharge = []
     helicityCharge.add(hist.getBinContent(0))
     helicityCharge.add(hist.getBinContent(1))

--- a/qa-physics/buildChargeTree.groovy
+++ b/qa-physics/buildChargeTree.groovy
@@ -85,7 +85,7 @@ dataFile.eachLine { line ->
 
   // fill tree
   if(sector==1) {
-    println "add $runnum $binnum"
+    // println "add $runnum $binnum"
     T.addLeaf(chargeTree,[runnum,binnum],
       {[
         'fcChargeMin':fcStart,

--- a/qa-physics/buildChargeTree.groovy
+++ b/qa-physics/buildChargeTree.groovy
@@ -15,24 +15,9 @@ inDir = args[0] + "/outdat"
 monDir = args[0] + "/outmon"
 //----------------------------------------------------------------------------------
 
-def monFile
-def inMdir = new TDirectory()
-def runPrevious = -1 // initialize the previous run number
-def binPrevious = -1 // initialize the previous bin number
-def helicity = []    // list to hold the helicity values per run per bin
 def helState = [-1,0,1]  // labels for the json file
-def tok
-int r=0
-def runnum, binnum, sector
-def eventNumMin, eventNumMax
-def timestampMin, timestampMax
-def nElec, nElecFT
-def fcStart, fcStop
-def ufcStart, ufcStop
-def livetime
-def fcCharge
-def ufcCharge
 def chargeTree = [:] // [runnum][binnum] -> charge
+def runTree = [:] // [runnum] -> list of bin numbers
 
 // open data_table.dat
 def dataFile = new File("${inDir}/data_table.dat")
@@ -40,52 +25,29 @@ if(!(dataFile.exists())) throw new Exception("data_table.dat not found")
 dataFile.eachLine { line ->
 
   // tokenize
-  tok = line.tokenize(' ')
-  r=0
-  runnum = tok[r++].toInteger()
-  binnum = tok[r++].toInteger()
-  eventNumMin = tok[r++].toBigInteger()
-  eventNumMax = tok[r++].toBigInteger()
-  timestampMin = tok[r++].toBigInteger()
-  timestampMax = tok[r++].toBigInteger()
-  sector = tok[r++].toInteger()
-  nElec = tok[r++].toBigDecimal()
-  nElecFT = tok[r++].toBigDecimal()
-  fcStart = tok[r++].toBigDecimal()
-  fcStop = tok[r++].toBigDecimal()
-  ufcStart = tok[r++].toBigDecimal()
-  ufcStop = tok[r++].toBigDecimal()
-  livetime = tok.size()>11 ? tok[r++].toBigDecimal() : -1
+  def tok = line.tokenize(' ')
+  int r=0
+  def runnum = tok[r++].toInteger()
+  def binnum = tok[r++].toInteger()
+  def eventNumMin = tok[r++].toBigInteger()
+  def eventNumMax = tok[r++].toBigInteger()
+  def timestampMin = tok[r++].toBigInteger()
+  def timestampMax = tok[r++].toBigInteger()
+  def sector = tok[r++].toInteger()
+  def nElec = tok[r++].toBigDecimal()
+  def nElecFT = tok[r++].toBigDecimal()
+  def fcStart = tok[r++].toBigDecimal()
+  def fcStop = tok[r++].toBigDecimal()
+  def ufcStart = tok[r++].toBigDecimal()
+  def ufcStop = tok[r++].toBigDecimal()
+  def livetime = tok.size()>11 ? tok[r++].toBigDecimal() : -1
 
-  // open monitor_<runnum>.hipo
-  // data_table.dat has lines that repeat the run number and bin number.
-  // Use runPrevious and binPrevious to avoid repeating the extraction of the histogram bin contents
-  if(runnum!=runPrevious){
-    runPrevious = runnum
-    binPrevious = -1
-    monFile = new File("${monDir}/monitor_${runnum}.hipo")
-    println "Opening $monFile"
-    if(!(monFile.exists())) throw new Exception("monitor<run>.hipo not found")
-    try {
-      inMdir.readFile(monDir + "/" + monFile.getName())
-    } catch(Exception ex) {
-      System.err.println("ERROR: cannot read file $monFile; it may be corrupt")
-      return
-    }
-  }
 
-  if(binnum!=binPrevious){
-    binPrevious = binnum
-    def histName = "helic_scaler_chargeWeighted_" + runnum + "_" + binnum
-    H1F hist = (H1F)inMdir.getObject(runnum + "/",histName);
-    helicity.add(hist.getBinContent(0))
-    helicity.add(hist.getBinContent(1))
-    helicity.add(hist.getBinContent(2))
-  }
 
   // fill tree
   if(sector==1) {
-    // println "add $runnum $binnum"
+    T.addLeaf(runTree, [runnum], {[]})
+    runTree[runnum].add(binnum)
     T.addLeaf(chargeTree,[runnum,binnum],
       {[
         'fcChargeMin':fcStart,
@@ -95,10 +57,35 @@ dataFile.eachLine { line ->
         'livetime':livetime
       ]}
     )
-    helState.eachWithIndex { it, i -> T.addLeaf(chargeTree,[runnum,binnum,'fcChargeHelicity',it],{helicity[i]})}
-    helicity.clear()  // reset the helicity list
   }
   T.addLeaf(chargeTree,[runnum,binnum,'nElec',sector],{nElec})
+}
+
+
+// open monitor_*.hipo files
+runTree.each { runnum, binnums ->
+
+  // open monitor_<runnum>.hipo
+  def monFile = new File("${monDir}/monitor_${runnum}.hipo")
+  def inMdir = new TDirectory()
+  if(!(monFile.exists())) throw new Exception("monitor<run>.hipo not found")
+  try {
+    inMdir.readFile(monDir + "/" + monFile.getName())
+  } catch(Exception ex) {
+    System.err.println("ERROR: cannot read file $monFile; it may be corrupt")
+    System.exit(100)
+  }
+
+  // add helicity-latched charge for each bin
+  binnums.each { binnum ->
+    def histName = "helic_scaler_chargeWeighted_" + runnum + "_" + binnum
+    hist = (H1F)inMdir.getObject(runnum + "/",histName);
+    def helicityCharge = []
+    helicityCharge.add(hist.getBinContent(0))
+    helicityCharge.add(hist.getBinContent(1))
+    helicityCharge.add(hist.getBinContent(2))
+    helState.eachWithIndex { it, i -> T.addLeaf(chargeTree,[runnum,binnum,'fcChargeHelicity',it],{helicityCharge[i]})}
+  }
 }
 
 chargeTree.each { chargeRun, chargeRunTree -> chargeRunTree.sort{it.key.toInteger()} }


### PR DESCRIPTION
fixes #281 

Moves `monitor_*.hipo` file handling to its own loop, which iterates over QA bins for each run.

HIPO files were not being closed, since `monFile` and `inMdir` never go out of scope; each new file and its histograms persists in memory. 

Basically, instead of 
```groovy
def obj // global scope
run_list.each {
  obj = new ...
}
```
do this:
```groovy
run_list.each {
  def obj = new ... // scoped for only this iteration
}
```