### PR TITLE
refactor: move FC charge non-monotonicity to `PHYS_QA_EXTRA` webpage

### DIFF
--- a/qa-physics/stageTimelines.sh
+++ b/qa-physics/stageTimelines.sh
@@ -41,6 +41,7 @@ extraList=(
   electron_FT_yield_QA_epoch_view
   electron_FT_yield_stddev
   electron_FT_yield_values
+  faraday_cup_charge_non-monotonicity
   faraday_cup_stddev
   helicity_sinPhi
   live_time_average


### PR DESCRIPTION
This timeline is not so important for Pass readiness reviews, _etc._