### PR TITLE
feat(timeline): add support for second peak data in forward tracking Vz

### DIFF
--- a/detectors/src/main/java/org/jlab/clas/timeline/fitter/ForwardFitter.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/fitter/ForwardFitter.groovy
@@ -11,20 +11,18 @@ import org.jlab.groot.math.F1D
 
 
 class ForwardFitter{
-static F1D fitBimodal(H1F h1) {
+static F1D fitBimodal(H1F h1, float mean1, float mean2, float sigma1, float sigma2, float range_min, float range_max) {
 	    def f1 = new F1D("fit:"+h1.getName(), "[amp1]*gaus(x,[mean1],[sigma1])+[amp2]*gaus(x,[mean2],[sigma2])+[p0]+[p1]*x", -9.0, 0.0);
         double hAmp  = h1.getBinContent(h1.getMaximumBin());
         double hMean = h1.getAxis().getBinCenter(h1.getMaximumBin());
         double hRMS  = h1.getRMS();
-        double rangeMin = (-9);
-        double rangeMax = (0);
-        f1.setRange(rangeMin, rangeMax);
+        f1.setRange(range_min, range_max);
         f1.setParameter(0, hAmp);
-        f1.setParameter(1, -8);
-        f1.setParameter(2, 0.5);
+        f1.setParameter(1, mean1);
+        f1.setParameter(2, sigma1);
 		f1.setParameter(3, hAmp);
-        f1.setParameter(4, -3);
-        f1.setParameter(5, 0.5);
+        f1.setParameter(4, mean2);
+        f1.setParameter(5, sigma2);
 		f1.setParameter(6, 1);
 		f1.setParameter(7, 1);
 		MoreFitter.fit(f1,h1,"LQ");
@@ -38,7 +36,7 @@ static F1D fitBimodal(H1F h1) {
 			hRMS1 = func.getParameter(2).abs()
 			hMean2 = func.getParameter(4)
 			hRMS2 = func.getParameter(5).abs()
-			func.setRange(-9, 0)
+			func.setRange(range_min, range_max)
 			MoreFitter.fit(func,h1,"Q")
 
 			return [func.getChiSquare(), (0..<func.getNPars()).collect{func.getParameter(it)}]

--- a/detectors/src/main/java/org/jlab/clas/timeline/timeline/forward/forward_Tracking_EleVz.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/timeline/forward/forward_Tracking_EleVz.groovy
@@ -7,25 +7,50 @@ import org.jlab.clas.timeline.fitter.ForwardFitter
 class forward_Tracking_EleVz {
 
 def data = new ConcurrentHashMap()
+def data_2nd_peak = new ConcurrentHashMap()
+
+def is_RGD_LD2 = { run ->
+  return ((18305 <= run && run <= 18313) ||
+          (18317 <= run && run <= 18336) ||
+          (18419 <= run && run <= 18439) ||
+          (18528 <= run && run <= 18559) ||
+          (18644 <= run && run <= 18656) || 
+          (18763 <= run && run <= 18790) || 
+          (18851 <= run && run <= 18873) || 
+          (18977 <= run && run <= 19059))
+}
 
 def processDirectory(dir, run) {
   def funclist = []
   def meanlist = []
   def sigmalist = []
   def chi2list = []
+
+  def funclist_2nd_peak = []
+  def meanlist_2nd_peak = []
+  def sigmalist_2nd_peak = []
+  def chi2list_2nd_peak = []
+
   def histlist =   (0..<6).collect{
     def h1 = dir.getObject('/elec/H_trig_vz_mom_S'+(it+1)).projectionY()
     h1.setName("sec"+(it+1))
     h1.setTitle("VZ of electrons")
     h1.setTitleX("VZ of electrons (cm)")
 
+    def usefitBimodal = false
     def f1
     if(run >= 18305 && run <= 19131) {
-      if ((run == 18580) || (18305 <= run && run <= 18336) ||  (18396 <= run && run <= 18399) || (18406 <= run && run <= 18439) || (18644 <= run && run <= 18656) || (18764 <= run && run <= 18790) || (18851 <= run && run <= 18873) || (18977 <= run && run <= 19060)) {
+      if (is_RGD_LD2(run)) {
         f1 = ForwardFitter.fit(h1)
       }
       else {
-        f1 = ForwardFitter.fitBimodal(h1)
+        if (run == 18399) {
+          f1 = ForwardFitter.fitBimodal(h1, -17.5, -13, 1, 1, -19, -10)
+          }
+        else {
+          f1 = ForwardFitter.fitBimodal(h1, -8, -3, 0.8, 0.8, -10, 0)
+        }
+        usefitBimodal = true
       }
     } else {
       f1 = ForwardFitter.fit(h1)
@@ -35,9 +60,20 @@ def processDirectory(dir, run) {
     meanlist.add(f1.getParameter(1))
     sigmalist.add(f1.getParameter(2).abs())
     chi2list.add(f1.getChiSquare())
+
+    if (usefitBimodal) {
+      funclist_2nd_peak.add(f1)
+      meanlist_2nd_peak.add(f1.getParameter(4))
+      sigmalist_2nd_peak.add(f1.getParameter(5).abs())
+      chi2list_2nd_peak.add(f1.getChiSquare())
+    }
+
     return h1
   }
   data[run] = [run:run, hlist:histlist, flist:funclist, mean:meanlist, sigma:sigmalist, clist:chi2list]
+  if (funclist_2nd_peak.size() > 0) {
+    data_2nd_peak[run] = [run:run, hlist:histlist, flist:funclist_2nd_peak, mean:meanlist_2nd_peak, sigma:sigmalist_2nd_peak, clist:chi2list_2nd_peak]
+  }
 }
 
 
@@ -61,8 +97,21 @@ def close() {
       out.addDataSet(it.flist[sec])
       grtl.addPoint(it.run, it.mean[sec], 0, 0)
     }
+
+    def grtl_2nd_peak = new GraphErrors('sec'+(sec+1)+'_2')
+    grtl_2nd_peak.setTitle("VZ (peak value) for electrons per sector")
+    grtl_2nd_peak.setTitleY("VZ (peak value) for electrons per sector (cm)")
+    grtl_2nd_peak.setTitleX("run number")
+    data_2nd_peak.sort{it.key}.each{run,it->
+      grtl_2nd_peak.addPoint(it.run, it.mean[sec], 0, 0)
+    }
+
     out.cd('/timelines')
     out.addDataSet(grtl)
+
+    if (data_2nd_peak.size() != 0) {
+      out.addDataSet(grtl_2nd_peak)
+    }
   }
 
   out.writeFile('forward_electron_VZ.hipo')

--- a/detectors/src/main/java/org/jlab/clas/timeline/timeline/forward/forward_Tracking_NegVz.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/timeline/forward/forward_Tracking_NegVz.groovy
@@ -7,24 +7,49 @@ import org.jlab.clas.timeline.fitter.ForwardFitter
 class forward_Tracking_NegVz {
 
 def data = new ConcurrentHashMap()
+def data_2nd_peak = new ConcurrentHashMap()
+
+def is_RGD_LD2 = { run ->
+  return ((18305 <= run && run <= 18313) ||
+          (18317 <= run && run <= 18336) ||
+          (18419 <= run && run <= 18439) ||
+          (18528 <= run && run <= 18559) ||
+          (18644 <= run && run <= 18656) || 
+          (18763 <= run && run <= 18790) || 
+          (18851 <= run && run <= 18873) || 
+          (18977 <= run && run <= 19059))
+}
 
 def processDirectory(dir, run) {
   def funclist = []
   def meanlist = []
   def sigmalist = []
   def chi2list = []
+
+  def funclist_2nd_peak = []
+  def meanlist_2nd_peak = []
+  def sigmalist_2nd_peak = []
+  def chi2list_2nd_peak = []
+
   def histlist =   (0..<6).collect{
     def h1 = dir.getObject('/dc/H_dcm_vz_s'+(it+1))
     h1.setTitle("VZ of negatives")
     h1.setTitleX("VZ of negatives (cm)")
-
+    
+    def usefitBimodal = false
     def f1
     if(run >= 18305 && run <= 19131) {
-      if ((run == 18580) || (18305 <= run && run <= 18336) ||  (18396 <= run && run <= 18399) || (18406 <= run && run <= 18439) || (18644 <= run && run <= 18656) || (18764 <= run && run <= 18790) || (18851 <= run && run <= 18873) || (18977 <= run && run <= 19060)) {
+      if (is_RGD_LD2(run)) {
         f1 = ForwardFitter.fit(h1)
       }
       else {
-        f1 = ForwardFitter.fitBimodal(h1)
+        if (run == 18399) {
+          f1 = ForwardFitter.fitBimodal(h1, -17.5, -13, 1, 1, -19, -10)
+          }
+        else {
+          f1 = ForwardFitter.fitBimodal(h1, -8, -3, 0.8, 0.8, -10, 0)
+        }
+        usefitBimodal = true
       }
     } else {
       f1 = ForwardFitter.fit(h1)
@@ -34,9 +59,20 @@ def processDirectory(dir, run) {
     meanlist.add(f1.getParameter(1))
     sigmalist.add(f1.getParameter(2).abs())
     chi2list.add(f1.getChiSquare())
+
+    if (usefitBimodal) {
+      funclist_2nd_peak.add(f1)
+      meanlist_2nd_peak.add(f1.getParameter(4))
+      sigmalist_2nd_peak.add(f1.getParameter(5).abs())
+      chi2list_2nd_peak.add(f1.getChiSquare())
+    }
+
     return h1
   }
   data[run] = [run:run, hlist:histlist, flist:funclist, mean:meanlist, sigma:sigmalist, clist:chi2list]
+  if (funclist_2nd_peak.size() > 0) {
+    data_2nd_peak[run] = [run:run, hlist:histlist, flist:funclist_2nd_peak, mean:meanlist_2nd_peak, sigma:sigmalist_2nd_peak, clist:chi2list_2nd_peak]
+  }
 }
 
 
@@ -60,8 +96,21 @@ def close() {
       out.addDataSet(it.flist[sec])
       grtl.addPoint(it.run, it.mean[sec], 0, 0)
     }
+
+    def grtl_2nd_peak = new GraphErrors('sec'+(sec+1)+'_2')
+    grtl_2nd_peak.setTitle("VZ (peak value) for electrons per sector")
+    grtl_2nd_peak.setTitleY("VZ (peak value) for electrons per sector (cm)")
+    grtl_2nd_peak.setTitleX("run number")
+    data_2nd_peak.sort{it.key}.each{run,it->
+      grtl_2nd_peak.addPoint(it.run, it.mean[sec], 0, 0)
+    }
+
     out.cd('/timelines')
     out.addDataSet(grtl)
+
+    if (data_2nd_peak.size() != 0) {
+      out.addDataSet(grtl_2nd_peak)
+    }
   }
 
   out.writeFile('forward_negative_VZ.hipo')

--- a/detectors/src/main/java/org/jlab/clas/timeline/timeline/forward/forward_Tracking_PosVz.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/timeline/forward/forward_Tracking_PosVz.groovy
@@ -7,24 +7,49 @@ import org.jlab.clas.timeline.fitter.ForwardFitter
 class forward_Tracking_PosVz {
 
 def data = new ConcurrentHashMap()
+def data_2nd_peak = new ConcurrentHashMap()
+
+def is_RGD_LD2 = { run ->
+  return ((18305 <= run && run <= 18313) ||
+          (18317 <= run && run <= 18336) ||
+          (18419 <= run && run <= 18439) ||
+          (18528 <= run && run <= 18559) ||
+          (18644 <= run && run <= 18656) || 
+          (18763 <= run && run <= 18790) || 
+          (18851 <= run && run <= 18873) || 
+          (18977 <= run && run <= 19059))
+}
 
 def processDirectory(dir, run) {
   def funclist = []
   def meanlist = []
   def sigmalist = []
   def chi2list = []
+
+  def funclist_2nd_peak = []
+  def meanlist_2nd_peak = []
+  def sigmalist_2nd_peak = []
+  def chi2list_2nd_peak = []
+
   def histlist =   (0..<6).collect{
     def h1 = dir.getObject('/dc/H_dcp_vz_s'+(it+1))
     h1.setTitle("VZ, negatives")
     h1.setTitleX("VZ, negatives (cm)")
 
+    def usefitBimodal = false
     def f1
     if(run >= 18305 && run <= 19131) {
-      if ((run == 18580) || (18305 <= run && run <= 18336) ||  (18396 <= run && run <= 18399) || (18406 <= run && run <= 18439) || (18644 <= run && run <= 18656) || (18764 <= run && run <= 18790) || (18851 <= run && run <= 18873) || (18977 <= run && run <= 19060)) {
+      if (is_RGD_LD2(run)) {
         f1 = ForwardFitter.fit(h1)
       }
       else {
-        f1 = ForwardFitter.fitBimodal(h1)
+        if (run == 18399) {
+          f1 = ForwardFitter.fitBimodal(h1, -17.5, -13, 1, 1, -19, -10)
+          }
+        else {
+          f1 = ForwardFitter.fitBimodal(h1, -8, -3, 0.8, 0.8, -10, 0)
+        }
+        usefitBimodal = true
       }
     } else {
       f1 = ForwardFitter.fit(h1)
@@ -33,9 +58,21 @@ def processDirectory(dir, run) {
     meanlist.add(f1.getParameter(1))
     sigmalist.add(f1.getParameter(2).abs())
     chi2list.add(f1.getChiSquare())
+
+    if (usefitBimodal) {
+      funclist_2nd_peak.add(f1)
+      meanlist_2nd_peak.add(f1.getParameter(4))
+      sigmalist_2nd_peak.add(f1.getParameter(5).abs())
+      chi2list_2nd_peak.add(f1.getChiSquare())
+    }
+
+
     return h1
   }
   data[run] = [run:run, hlist:histlist, flist:funclist, mean:meanlist, sigma:sigmalist, clist:chi2list]
+  if (funclist_2nd_peak.size() > 0) {
+    data_2nd_peak[run] = [run:run, hlist:histlist, flist:funclist_2nd_peak, mean:meanlist_2nd_peak, sigma:sigmalist_2nd_peak, clist:chi2list_2nd_peak]
+  }
 }
 
 
@@ -59,8 +96,21 @@ def close() {
       out.addDataSet(it.flist[sec])
       grtl.addPoint(it.run, it.mean[sec], 0, 0)
     }
+
+    def grtl_2nd_peak = new GraphErrors('sec'+(sec+1)+'_2')
+    grtl_2nd_peak.setTitle("VZ (peak value) for electrons per sector")
+    grtl_2nd_peak.setTitleY("VZ (peak value) for electrons per sector (cm)")
+    grtl_2nd_peak.setTitleX("run number")
+    data_2nd_peak.sort{it.key}.each{run,it->
+      grtl_2nd_peak.addPoint(it.run, it.mean[sec], 0, 0)
+    }
+
     out.cd('/timelines')
     out.addDataSet(grtl)
+
+    if (data_2nd_peak.size() != 0) {
+      out.addDataSet(grtl_2nd_peak)
+    }
   }
 
   out.writeFile('forward_positive_VZ.hipo')


### PR DESCRIPTION
Change the track forward timelines to handle two peaks and display them in the timelines. 
- create new data to store the second peak and other info.
- Add range and parameters for the bimodal fit function


Fix run range for liquid and solid targets for RG-D.


![image](https://github.com/user-attachments/assets/6883f3df-3298-4ac7-acbc-b964b3c12c4e)
