### PR TITLE
fix(htcc_vtimediff): increase `sigma` fit-param min

### DIFF
--- a/detectors/src/main/java/org/jlab/clas/timeline/fitter/HTCCFitter.groovy
+++ b/detectors/src/main/java/org/jlab/clas/timeline/fitter/HTCCFitter.groovy
@@ -28,12 +28,13 @@ class HTCCFitter{
 
     f1.setParameter(0, h1.getMax());
     f1.setParameter(1, maxV);
+    def absolute_min_sigma = 0.2
     if(iqr > 0) {
       f1.setParameter(2, Math.max(iqr / 2.0, 0.1));
-      f1.setParLimits(2, Math.max(iqr / 5.0, 0.05), Math.min(iqr * 5.0, h1.getAxis().getBinCenter(h1.getAxis().getNBins()-1)));
+      f1.setParLimits(2, Math.max(iqr / 5.0, absolute_min_sigma), Math.min(iqr * 5.0, h1.getAxis().getBinCenter(h1.getAxis().getNBins()-1)));
     } else {
       f1.setParameter(2, 0.1);
-      f1.setParLimits(2, 0.05, h1.getAxis().getBinCenter(h1.getAxis().getNBins()-1));
+      f1.setParLimits(2, absolute_min_sigma, h1.getAxis().getBinCenter(h1.getAxis().getNBins()-1));
     }
 
     DataFitter.fit(f1, h1, "");


### PR DESCRIPTION
Very narrow gaussians seem to be causing the following crashes in RG-E timelines:
```
java.lang.RuntimeException: Something is wrong!
	at org.freehep.math.minuit.VariableMetricBuilder.minimum(VariableMetricBuilder.java:50)
	at org.freehep.math.minuit.VariableMetricBuilder.minimum(VariableMetricBuilder.java:21)
	at org.freehep.math.minuit.ModularFunctionMinimizer.minimize(ModularFunctionMinimizer.java:29)
	at org.freehep.math.minuit.ModularFunctionMinimizer.minimize(ModularFunctionMinimizer.java:21)
	at org.freehep.math.minuit.MnApplication.minimize(MnApplication.java:58)
	at org.freehep.math.minuit.MnApplication.minimize(MnApplication.java:43)
	at org.freehep.math.minuit.MnApplication.minimize(MnApplication.java:39)
	at org.jlab.groot.fitter.DataFitter.fit(DataFitter.java:84)
	at org.jlab.groot.fitter.DataFitter$fit.call(Unknown Source)
	at org.jlab.clas.timeline.fitter.HTCCFitter.timeIndPMT(HTCCFitter.groovy:39)
	at org.jlab.clas.timeline.fitter.HTCCFitter$timeIndPMT.call(Unknown Source)
	at org.jlab.clas.timeline.timeline.htcc.htcc_vtimediff$_processDirectory_closure1.doCall(htcc_vtimediff.groovy:17)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:343)
	at org.codehaus.groovy.runtime.metaclass.TransformMetaMethod.invoke(TransformMetaMethod.java:59)
	at groovy.lang.MetaClassImpl$3.invoke(MetaClassImpl.java:1374)
	at org.codehaus.groovy.runtime.metaclass.TransformMetaMethod.doMethodInvoke(TransformMetaMethod.java:66)
	at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:279)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1007)
	at groovy.lang.Closure.call(Closure.java:433)
	at groovy.lang.Closure.call(Closure.java:422)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2394)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2379)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2420)
	at org.codehaus.groovy.runtime.dgm$207.invoke(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite$PojoMetaMethodSiteNoUnwrapNoCoerce.invoke(PojoMetaMethodSite.java:253)
	at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite.call(PojoMetaMethodSite.java:57)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:139)
	at org.jlab.clas.timeline.timeline.htcc.htcc_vtimediff.processDirectory(htcc_vtimediff.groovy:15)
	at org.jlab.clas.timeline.timeline.htcc.htcc_vtimediff$processDirectory.call(Unknown Source)
	at org.jlab.clas.timeline.run_detectors$_run_closure6.doCall(run_detectors.groovy:175)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:343)
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:328)
	at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:279)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1007)
	at groovy.lang.Closure.call(Closure.java:433)
	at groovy.lang.Closure.call(Closure.java:422)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2394)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2379)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2420)
	at org.codehaus.groovy.runtime.dgm$207.invoke(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite$PojoMetaMethodSiteNoUnwrapNoCoerce.invoke(PojoMetaMethodSite.java:253)
	at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite.call(PojoMetaMethodSite.java:57)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:45)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:139)
	at org.jlab.clas.timeline.run_detectors.run(run_detectors.groovy:163)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:343)
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:328)
	at groovy.lang.MetaClassImpl.doInvokeMethod(MetaClassImpl.java:1333)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1088)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1007)
	at org.codehaus.groovy.runtime.InvokerHelper.invokePogoMethod(InvokerHelper.java:645)
	at org.codehaus.groovy.runtime.InvokerHelper.invokeMethod(InvokerHelper.java:628)
	at org.codehaus.groovy.runtime.InvokerHelper.runScript(InvokerHelper.java:422)
	at org.codehaus.groovy.runtime.InvokerHelper$runScript.callStatic(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallStatic(CallSiteArray.java:53)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callStatic(AbstractCallSite.java:217)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callStatic(AbstractCallSite.java:240)
	at org.jlab.clas.timeline.run_detectors.main(run_detectors.groovy)
```
Increasing the minimum allowed `sigma` from 0.05 to 0.2 appears to have fixed the issue; 0.05 is extremely small, and most of the data are well above 0.2.