### PR TITLE
build: much quieter Maven output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: build
-        run: ./install.sh
+        run: mvn install
       - name: tar # to preserve any permissions
         run: |
           tar cavf build_timeline.tar.zst target

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+--no-transfer-progress

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -7,9 +7,9 @@ module load timeline/dev   # load the 'dev' version (likely the most recent vers
 module load timeline/1.0.0 # alternatively, load a specific version, such as 1.0.0
 ```
 
-If you want to install locally, clone the repository, then run:
+If you want to install locally, clone the repository, `cd` into it, then run:
 ```bash
-./install.sh
+mvn install
 ```
 
 The directory `target/` will contain the build files, which are mostly JAR files.

--- a/install.sh
+++ b/install.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-exec mvn install dependency:copy-dependencies

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,24 @@
           </dependency>
         </dependencies>
       </plugin>
+      <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-dependency-plugin -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.8.1</version>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/dependency</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
- use `--no-transfer-progress` to avoid filling CI logs with about 30,000 completely useless lines of download progress status
- use `maven-dependency-plugin` goal `copy-dependencies` instead of running the goal from the command line (via wrapper script), which seems to be much quieter too
- now we're back to just running `maven install` instead of a wrapper (`install.sh`)