### PR TITLE
perf(ci): revert `download_test_data` to use runner rather than container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,7 @@ jobs:
 
   download_test_data:
     runs-on: ubuntu-latest
-    container:
-      image: codecr.jlab.org/hallb/clas12/container-forge/base:latest
-      options: --user root
+   # NOTE: using Ubuntu runner, rather than a `container-forge` image, since it's much faster for cache hits
     strategy:
       fail-fast: true
       matrix:
@@ -64,6 +62,12 @@ jobs:
           key: validation_files_${{ matrix.type }}
           path: validation_files.tar.zst
           lookup-only: true
+      - name: install dependencies
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        run: |
+          sudo apt -y update
+          sudo apt -y upgrade
+          sudo apt -y install xrootd-client
       - name: download
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: xrdcp ${{ env.xrootd_file }} ./


### PR DESCRIPTION
When the cache hits (which is pretty much always), it's much faster to just use the runner, rather than wait for the container image pull. The job will be about 4 seconds, rather than 1-3 minutes.