### PR TITLE
fix: do not try to write empty `ftof_ctof_vtdiff` timeline

### DIFF
--- a/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_atof_tdc.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_atof_tdc.groovy
@@ -41,7 +41,7 @@ def has_data = new AtomicBoolean(false)
   def write() {
 
     if(!has_data.get()) {
-      System.err.println "ERROR: no data for this ALERT timeline, not producing"
+      System.err.println "WARNING: no data for this timeline, not producing"
       return
     }
 


### PR DESCRIPTION
Instead, warn about it. These timelines are empty for RG-L data.

_cf_. #308 