### PR TITLE
fix: `qtl analysis` option `--debug` should require `-t`

### DIFF
--- a/bin/qtl-analysis
+++ b/bin/qtl-analysis
@@ -185,7 +185,7 @@ if ${modes['debug']}; then
   enableAna=true
   enablePub=false
   if [ -z "$singleTimeline" ]; then
-    printError "DEBUG mode used, but you need to choose a timeline with '-t'"
+    printError "DEBUG mode used, but you need to also choose a timeline with '-t'"
     exit 100
   fi
 fi

--- a/bin/qtl-analysis
+++ b/bin/qtl-analysis
@@ -96,7 +96,7 @@ usageVerbose() {
     --skip-mya          skip timelines which require MYA (needed if running offsite or on CI)
 
     --debug             enable debug mode: run a single timeline with stderr and stdout printed to screen;
-                        it is best to use this with the '-t' option to debug specific timeline issues
+                        use this with the '-t' option to debug specific timeline issues
 
     -h, --help          print this usage guide
   """ >&2
@@ -184,6 +184,10 @@ if ${modes['debug']}; then
   printWarning "DEBUG mode used; timelines will NOT be published"
   enableAna=true
   enablePub=false
+  if [ -z "$singleTimeline" ]; then
+    printError "DEBUG mode used, but you need to choose a timeline with '-t'"
+    exit 100
+  fi
 fi
 
 ##################################################################################


### PR DESCRIPTION
`--debug` is used to help debug a single timeline, so just require `-t`.