### PR TITLE
refactor: run-number dependent conditionals should use `RunDependentCut`

### DIFF
--- a/src/main/java/org/jlab/clas/timeline/analysis/forward/forward_Tracking_EleVz.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/forward/forward_Tracking_EleVz.groovy
@@ -3,6 +3,7 @@ import java.util.concurrent.ConcurrentHashMap
 import org.jlab.groot.data.TDirectory
 import org.jlab.groot.data.GraphErrors
 import org.jlab.clas.timeline.fitter.ForwardFitter
+import org.jlab.clas.timeline.util.RunDependentCut;
 
 class forward_Tracking_EleVz {
 
@@ -10,14 +11,14 @@ def data = new ConcurrentHashMap()
 def data_2nd_peak = new ConcurrentHashMap()
 
 def is_RGD_LD2 = { run ->
-  return ((18305 <= run && run <= 18313) ||
-          (18317 <= run && run <= 18336) ||
-          (18419 <= run && run <= 18439) ||
-          (18528 <= run && run <= 18559) ||
-          (18644 <= run && run <= 18656) || 
-          (18763 <= run && run <= 18790) || 
-          (18851 <= run && run <= 18873) || 
-          (18977 <= run && run <= 19059))
+  return (RunDependentCut.runIsInRange(run, 18305, 18313, true) ||
+          RunDependentCut.runIsInRange(run, 18317, 18336, true) ||
+          RunDependentCut.runIsInRange(run, 18419, 18439, true) ||
+          RunDependentCut.runIsInRange(run, 18528, 18559, true) ||
+          RunDependentCut.runIsInRange(run, 18644, 18656, true) ||
+          RunDependentCut.runIsInRange(run, 18763, 18790, true) ||
+          RunDependentCut.runIsInRange(run, 18851, 18873, true) ||
+          RunDependentCut.runIsInRange(run, 18977, 19059, true))
 }
 
 def processRun(dir, run) {
@@ -39,14 +40,14 @@ def processRun(dir, run) {
 
     def usefitBimodal = false
     def f1
-    if(run >= 18305 && run <= 19131) {
+    if (RunDependentCut.runIsInRange(run, 18305, 19131, true)) {
       if (is_RGD_LD2(run)) {
         f1 = ForwardFitter.fit(h1)
       }
       else {
-        if (run == 18399) {
+        if (RunDependentCut.runIsOneOf(run, 18399)) {
           f1 = ForwardFitter.fitBimodal(h1, -17.5, -13, 1, 1, -19, -10)
-          }
+        }
         else {
           f1 = ForwardFitter.fitBimodal(h1, -8, -3, 0.8, 0.8, -10, 0)
         }

--- a/src/main/java/org/jlab/clas/timeline/analysis/forward/forward_Tracking_NegVz.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/forward/forward_Tracking_NegVz.groovy
@@ -3,6 +3,7 @@ import java.util.concurrent.ConcurrentHashMap
 import org.jlab.groot.data.TDirectory
 import org.jlab.groot.data.GraphErrors
 import org.jlab.clas.timeline.fitter.ForwardFitter
+import org.jlab.clas.timeline.util.RunDependentCut;
 
 class forward_Tracking_NegVz {
 
@@ -10,14 +11,14 @@ def data = new ConcurrentHashMap()
 def data_2nd_peak = new ConcurrentHashMap()
 
 def is_RGD_LD2 = { run ->
-  return ((18305 <= run && run <= 18313) ||
-          (18317 <= run && run <= 18336) ||
-          (18419 <= run && run <= 18439) ||
-          (18528 <= run && run <= 18559) ||
-          (18644 <= run && run <= 18656) || 
-          (18763 <= run && run <= 18790) || 
-          (18851 <= run && run <= 18873) || 
-          (18977 <= run && run <= 19059))
+  return (RunDependentCut.runIsInRange(run, 18305, 18313, true) ||
+          RunDependentCut.runIsInRange(run, 18317, 18336, true) ||
+          RunDependentCut.runIsInRange(run, 18419, 18439, true) ||
+          RunDependentCut.runIsInRange(run, 18528, 18559, true) ||
+          RunDependentCut.runIsInRange(run, 18644, 18656, true) ||
+          RunDependentCut.runIsInRange(run, 18763, 18790, true) ||
+          RunDependentCut.runIsInRange(run, 18851, 18873, true) ||
+          RunDependentCut.runIsInRange(run, 18977, 19059, true))
 }
 
 def processRun(dir, run) {
@@ -35,17 +36,17 @@ def processRun(dir, run) {
     def h1 = dir.getObject('/dc/H_dcm_vz_s'+(it+1))
     h1.setTitle("VZ of negatives")
     h1.setTitleX("VZ of negatives (cm)")
-    
+
     def usefitBimodal = false
     def f1
-    if(run >= 18305 && run <= 19131) {
+    if (RunDependentCut.runIsInRange(run, 18305, 19131, true)) {
       if (is_RGD_LD2(run)) {
         f1 = ForwardFitter.fit(h1)
       }
       else {
-        if (run == 18399) {
+        if (RunDependentCut.runIsOneOf(run, 18399)) {
           f1 = ForwardFitter.fitBimodal(h1, -17.5, -13, 1, 1, -19, -10)
-          }
+        }
         else {
           f1 = ForwardFitter.fitBimodal(h1, -8, -3, 0.8, 0.8, -10, 0)
         }

--- a/src/main/java/org/jlab/clas/timeline/analysis/forward/forward_Tracking_PosVz.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/forward/forward_Tracking_PosVz.groovy
@@ -3,6 +3,7 @@ import java.util.concurrent.ConcurrentHashMap
 import org.jlab.groot.data.TDirectory
 import org.jlab.groot.data.GraphErrors
 import org.jlab.clas.timeline.fitter.ForwardFitter
+import org.jlab.clas.timeline.util.RunDependentCut;
 
 class forward_Tracking_PosVz {
 
@@ -10,14 +11,14 @@ def data = new ConcurrentHashMap()
 def data_2nd_peak = new ConcurrentHashMap()
 
 def is_RGD_LD2 = { run ->
-  return ((18305 <= run && run <= 18313) ||
-          (18317 <= run && run <= 18336) ||
-          (18419 <= run && run <= 18439) ||
-          (18528 <= run && run <= 18559) ||
-          (18644 <= run && run <= 18656) || 
-          (18763 <= run && run <= 18790) || 
-          (18851 <= run && run <= 18873) || 
-          (18977 <= run && run <= 19059))
+  return (RunDependentCut.runIsInRange(run, 18305, 18313, true) ||
+          RunDependentCut.runIsInRange(run, 18317, 18336, true) ||
+          RunDependentCut.runIsInRange(run, 18419, 18439, true) ||
+          RunDependentCut.runIsInRange(run, 18528, 18559, true) ||
+          RunDependentCut.runIsInRange(run, 18644, 18656, true) ||
+          RunDependentCut.runIsInRange(run, 18763, 18790, true) ||
+          RunDependentCut.runIsInRange(run, 18851, 18873, true) ||
+          RunDependentCut.runIsInRange(run, 18977, 19059, true))
 }
 
 def processRun(dir, run) {
@@ -38,14 +39,14 @@ def processRun(dir, run) {
 
     def usefitBimodal = false
     def f1
-    if(run >= 18305 && run <= 19131) {
+    if (RunDependentCut.runIsInRange(run, 18305, 19131, true)) {
       if (is_RGD_LD2(run)) {
         f1 = ForwardFitter.fit(h1)
       }
       else {
-        if (run == 18399) {
+        if (RunDependentCut.runIsOneOf(run, 18399)) {
           f1 = ForwardFitter.fitBimodal(h1, -17.5, -13, 1, 1, -19, -10)
-          }
+        }
         else {
           f1 = ForwardFitter.fitBimodal(h1, -8, -3, 0.8, 0.8, -10, 0)
         }
@@ -54,6 +55,7 @@ def processRun(dir, run) {
     } else {
       f1 = ForwardFitter.fit(h1)
     }
+
     funclist.add(f1)
     meanlist.add(f1.getParameter(1))
     sigmalist.add(f1.getParameter(2).abs())
@@ -65,7 +67,6 @@ def processRun(dir, run) {
       sigmalist_2nd_peak.add(f1.getParameter(5).abs())
       chi2list_2nd_peak.add(f1.getChiSquare())
     }
-
 
     return h1
   }

--- a/src/main/java/org/jlab/clas/timeline/histograms/GeneralMon.java
+++ b/src/main/java/org/jlab/clas/timeline/histograms/GeneralMon.java
@@ -11,6 +11,7 @@ import org.jlab.clas.physics.Vector3;
 import org.jlab.clas.physics.LorentzVector;
 import org.jlab.utils.groups.IndexedTable;
 import org.jlab.detector.calib.utils.ConstantsManager;
+import org.jlab.clas.timeline.util.RunDependentCut;
 
 /**
  * General Monitoring histograms (a.k.a. General Monolith)
@@ -43,11 +44,12 @@ public class GeneralMon {
    */
   boolean testTriggerSector(int sector) {
     // FIXME:  move to CCDB
-    if (runNum > 18300 && runNum <= 19131) {
+
+    if (RunDependentCut.runIsInRange(runNum, 18301, 19131, true)) {
       // RG-D:   used three different primary electron triggers (0/7/14):
       return testTriggerSector(TriggerWord, sector, 0x4081);
     }
-    if (runNum > 16043 && runNum < 16078) {
+    if (RunDependentCut.runIsInRange(runNum, 16043, 16078, false)) {
       // RG-C 2.2 GeV:  non-standard primary electron trigger:
       return testTriggerSector(TriggerWord, sector, 0x4081);
     }
@@ -2517,7 +2519,7 @@ public class GeneralMon {
 
     for (int kk = 0; kk < 3; kk++) {
       tbit = kk + 7;
-      if (runNum <= 6296) {
+      if (RunDependentCut.runIsBefore(runNum, 6296, true)) {
         if (trigger_bits[tbit]) {
           if ((sectorp[kk] + sectorn[kk]) >= 1 && (sectorp[kk + 3] + sectorn[kk + 3]) >= 1) {
             H_trig_sector_muon.fill(kk + 1);
@@ -2527,7 +2529,7 @@ public class GeneralMon {
             Ntrackspair[kk] = sectorp[kk] + sectorn[kk + 3];
           }
         }
-      } else if (runNum > 6296 && runNum < 11000) {
+      } else if (RunDependentCut.runIsInRange(runNum, 6296, 11000, false)) {
         if (trigger_bits[tbit] || trigger_bits[tbit + 3]) {
           if ((sectorp[kk] + sectorn[kk]) >= 1 && (sectorp[kk + 3] + sectorn[kk + 3]) >= 1) {
             H_trig_sector_muon.fill(kk + 1);
@@ -2537,7 +2539,7 @@ public class GeneralMon {
             Ntrackspair[kk] = sectorp[kk] + sectorn[kk + 3];
           }
         }
-      } else if (runNum >= 11000) {
+      } else if (RunDependentCut.runIsAfter(runNum, 11000, true)) {
         if (trigger_bits[tbit] || trigger_bits[tbit + 3]) {
           if ((sectorp[kk] >= 1 && (sectorn[kk + 3]) >= 1) || (sectorn[kk] >= 1 && (sectorp[kk + 3]) >= 1)) {
             H_trig_sector_muon.fill(kk + 1);
@@ -3303,13 +3305,13 @@ public class GeneralMon {
     }
 
     if(trigger_bits[31])H_rand_trig_sector_count.fill(7);
-    if (runNum <= 6296) {
+    if (RunDependentCut.runIsBefore(runNum, 6296, true)) {
       if(trigger_bits[7]||trigger_bits[8]||trigger_bits[9])Nmuontrigs++;
       if(trigger_bits[7])H_muon_trig_sector_count.fill(1);
       if(trigger_bits[8])H_muon_trig_sector_count.fill(2);
       if(trigger_bits[9])H_muon_trig_sector_count.fill(3);
     }
-    else if (runNum > 6296) {
+    else if (RunDependentCut.runIsAfter(runNum, 6296, false)) {
       if(trigger_bits[7]||trigger_bits[8]||trigger_bits[9] || trigger_bits[10] || trigger_bits[11] || trigger_bits[12]) Nmuontrigs++;
       if(trigger_bits[7] || trigger_bits[10])H_muon_trig_sector_count.fill(1);
       if(trigger_bits[8] || trigger_bits[11])H_muon_trig_sector_count.fill(2);

--- a/src/main/java/org/jlab/clas/timeline/run_analysis.groovy
+++ b/src/main/java/org/jlab/clas/timeline/run_analysis.groovy
@@ -1,4 +1,5 @@
 package org.jlab.clas.timeline.analysis
+import org.jlab.clas.timeline.util.RunDependentCut
 
 import org.jlab.groot.data.TDirectory
 
@@ -165,7 +166,7 @@ if(eng) {
       def run = m[0].toInteger()
 
       // allow / disallow certain timelines, based on run number
-      if(run < 21317) { // before RG-L
+      if(RunDependentCut.runIsBefore(run, 21317, false)) { // before RG-L
         if(args[0] == "alert_atof_tdc") { allow_timeline = false }
       }
 

--- a/src/main/java/org/jlab/clas/timeline/util/RunDependentCut.groovy
+++ b/src/main/java/org/jlab/clas/timeline/util/RunDependentCut.groovy
@@ -1,0 +1,50 @@
+package org.jlab.clas.timeline.util
+
+/// @brief functions to handle run dependent things
+///
+/// Many of these functions are very simple, but we prefer to use them anyway so that
+/// it is easier to track what parts of the code involve run-number dependence.
+class RunDependentCut {
+
+  /// @param check_run the run number to check
+  /// @param cut_run the preferred run number
+  /// @returns true if `check_run` matches any of `cut_runs`
+  static boolean runIsOneOf(int check_run, int... cut_runs) {
+    return cut_runs.find{ it == check_run } != null;
+  }
+
+  /// @param check_run the run number to check
+  /// @param cut_run_lb the run number lower bound
+  /// @param cut_run_ub the run number upper bound
+  /// @param include_bound if true, include `cut_run_lb` and `cut_run_ub` in the range
+  /// @returns true if `check_run` is within range `cut_run_lb` and `cut_run_ub`
+  static boolean runIsInRange(int check_run, int cut_run_lb, int cut_run_ub, boolean include_bound) {
+    if(include_bound)
+      return check_run >= cut_run_lb && check_run <= cut_run_ub;
+    else
+      return check_run > cut_run_lb && check_run < cut_run_ub;
+  }
+
+  /// @param check_run the run number to check
+  /// @param cut_run the run number threshold
+  /// @param include_bound if true, include `cut_run` in the range
+  /// @returns true if `check_run` is before `cut_run`
+  static boolean runIsBefore(int check_run, int cut_run, boolean include_bound) {
+    if(include_bound)
+      return check_run <= cut_run;
+    else
+      return check_run < cut_run;
+  }
+
+  /// @param check_run the run number to check
+  /// @param cut_run the run number threshold
+  /// @param include_bound if true, include `cut_run` in the range
+  /// @returns true if `check_run` is after `cut_run`
+  static boolean runIsAfter(int check_run, int cut_run, boolean include_bound) {
+    if(include_bound)
+      return check_run >= cut_run;
+    else
+      return check_run > cut_run;
+  }
+
+}


### PR DESCRIPTION
We have a lot of run-number dependence throughout, which is currently tracked by #74. Instead of continuing to add to the list, in desperate hope of a general solution, let's mitigate by keeping track of _where_ the run-number dependent conditionals are used. We can do this by using custom run-number cut functions in a new class `RunDependentCut`.

We can't enforce its usage, but we can try to be consistent.

Many of these functions are very simple, but it makes it much easier to find all the run-dependent cuts, should we return to the idea of some configuration file implementation later.

I think this is good enough for now, since it's more flexible than a configuration file, so I'd say this closes #74.