### PR TITLE
Disable the ALERT: revert the changes in 0ad16c1 and 0118be5

### DIFF
--- a/bin/qtl-analysis
+++ b/bin/qtl-analysis
@@ -285,7 +285,7 @@ fi
 
 # output detector subdirectories
 detDirs=(
-  alert
+  # alert
   band
   bmtbst
   central

--- a/src/main/java/org/jlab/clas/timeline/run_analysis.groovy
+++ b/src/main/java/org/jlab/clas/timeline/run_analysis.groovy
@@ -3,8 +3,8 @@ package org.jlab.clas.timeline.analysis
 import org.jlab.groot.data.TDirectory
 
 def engines = [
-  out_ALERT: [new alert_atof_tdc(),
-  ],
+  // out_ALERT: [new alert_atof_tdc(),
+  // ],
   out_BAND: [new band_adccor(),
     new band_lasertime(),
     new band_meantimeadc(),


### PR DESCRIPTION
The RG-L chef reported that the fitting for the ATOF::tdc takes too long, and this has been an obstacle in producing the timeline.
We checked that the monitoring histograms were fine.
So I have disabled the ALERT timeline as a hot fix.
@c-dilks, Please release this version to the ifarm at your convenience.
Thank you!