### PR TITLE
refactor: add RG-D and RG-L to `RunDependentCut.findDataset`

### DIFF
--- a/src/main/java/org/jlab/clas/timeline/analysis/forward/forward_Tracking_EleVz.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/forward/forward_Tracking_EleVz.groovy
@@ -40,7 +40,7 @@ def processRun(dir, run) {
 
     def usefitBimodal = false
     def f1
-    if (RunDependentCut.runIsInRange(run, 18305, 19131, true)) {
+    if (RunDependentCut.findDataset(run) == 'rgd') {
       if (is_RGD_LD2(run)) {
         f1 = ForwardFitter.fit(h1)
       }

--- a/src/main/java/org/jlab/clas/timeline/analysis/forward/forward_Tracking_NegVz.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/forward/forward_Tracking_NegVz.groovy
@@ -39,7 +39,7 @@ def processRun(dir, run) {
 
     def usefitBimodal = false
     def f1
-    if (RunDependentCut.runIsInRange(run, 18305, 19131, true)) {
+    if (RunDependentCut.findDataset(run) == 'rgd') {
       if (is_RGD_LD2(run)) {
         f1 = ForwardFitter.fit(h1)
       }

--- a/src/main/java/org/jlab/clas/timeline/analysis/forward/forward_Tracking_PosVz.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/forward/forward_Tracking_PosVz.groovy
@@ -39,7 +39,7 @@ def processRun(dir, run) {
 
     def usefitBimodal = false
     def f1
-    if (RunDependentCut.runIsInRange(run, 18305, 19131, true)) {
+    if (RunDependentCut.findDataset(run) == 'rgd') {
       if (is_RGD_LD2(run)) {
         f1 = ForwardFitter.fit(h1)
       }

--- a/src/main/java/org/jlab/clas/timeline/histograms/GeneralMon.java
+++ b/src/main/java/org/jlab/clas/timeline/histograms/GeneralMon.java
@@ -45,7 +45,7 @@ public class GeneralMon {
   boolean testTriggerSector(int sector) {
     // FIXME:  move to CCDB
 
-    if (RunDependentCut.runIsInRange(runNum, 18301, 19131, true)) {
+    if (RunDependentCut.findDataset(runNum) == "rgd") {
       // RG-D:   used three different primary electron triggers (0/7/14):
       return testTriggerSector(TriggerWord, sector, 0x4081);
     }

--- a/src/main/java/org/jlab/clas/timeline/run_analysis.groovy
+++ b/src/main/java/org/jlab/clas/timeline/run_analysis.groovy
@@ -200,14 +200,15 @@ fnames.sort().each{ fname ->
 
     // exclude certain run ranges from certain timelines
     def allow_run = true
-    if(RunDependentCut.runIsBefore(run, 21317, false)) { // before RG-L
-      if(timelineArg ==~ /^alert.*/) { allow_run = false }
-    }
-    if(RunDependentCut.runIsAfter(run, 21317, true)) { // RG-L FIXME: needs upper bound when RG-L completes
+    def dataset = RunDependentCut.findDataset(run)
+    if(dataset == 'rgl') {
       if( timelineArg ==~ /^bmt.*/ ||
           timelineArg ==~ /^bst.*/ ||
           timelineArg ==~ /^cen.*/ ||
           timelineArg ==~ /^cvt.*/ ) { allow_run = false }
+    }
+    else { // not RG-L
+      if(timelineArg ==~ /^alert.*/) { allow_run = false }
     }
 
     // run the analysis for this run

--- a/src/main/java/org/jlab/clas/timeline/util/RunDependentCut.groovy
+++ b/src/main/java/org/jlab/clas/timeline/util/RunDependentCut.groovy
@@ -52,18 +52,22 @@ class RunDependentCut {
   static String findDataset(int... check_runs) {
     def datasets = check_runs.collect{ check_run ->
       if(runIsInRange(check_run, 5032, 5419, true))
-        return 'rga_fa18_inbending'
+        return 'rga_fa18_inbending';
       if(runIsInRange(check_run, 5423, 5666, true))
-        return 'rga_fa18_outbending'
+        return 'rga_fa18_outbending';
       if(runIsInRange(check_run, 16042, 16772, true))
-        return 'rgc_su22'
-      return 'unknown'
-    }.toUnique()
+        return 'rgc_su22';
+      if(runIsInRange(runNum, 18301, 19131, true))
+        return 'rgd';
+      if(runIsAfter(check_run, 21317, true)) // RG-L FIXME: needs upper bound when RG-L completes <https://github.com/JeffersonLab/clas12-timeline/issues/325>
+        return 'rgl';
+      return 'unknown';
+    }.toUnique();
     if(datasets.size() > 1) {
-      System.err.println "WARNING: RunDependentCut.findDataset run list spans more than one dataset: $datasets; returning the first one;"
-      System.err.println "WARNING:   runs: $check_runs"
+      System.err.println "WARNING: RunDependentCut.findDataset run list spans more than one dataset: $datasets; returning the first one;";
+      System.err.println "WARNING:   runs: $check_runs";
     }
-    return datasets[0]
+    return datasets[0];
   }
 
 }

--- a/src/main/java/org/jlab/clas/timeline/util/RunDependentCut.groovy
+++ b/src/main/java/org/jlab/clas/timeline/util/RunDependentCut.groovy
@@ -57,7 +57,7 @@ class RunDependentCut {
         return 'rga_fa18_outbending';
       if(runIsInRange(check_run, 16042, 16772, true))
         return 'rgc_su22';
-      if(runIsInRange(runNum, 18301, 19131, true))
+      if(runIsInRange(check_run, 18301, 19131, true))
         return 'rgd';
       if(runIsAfter(check_run, 21317, true)) // RG-L FIXME: needs upper bound when RG-L completes <https://github.com/JeffersonLab/clas12-timeline/issues/325>
         return 'rgl';


### PR DESCRIPTION
These are the only other ones we need for now. Following the YAGNI rule and not adding any others until needed.