### PR TITLE
fix: remove `run-monitoring.sh` symbolic link

### DIFF
--- a/bin/run-monitoring.sh
+++ b/bin/run-monitoring.sh
@@ -1,1 +1,0 @@
-qtl-histogram


### PR DESCRIPTION
Won't be needed soon. Let's wait some time before merging this, so leaving this PR in draft state for now.