### PR TITLE
fix(qtl-analysis): make output directory before `realpath`

### DIFF
--- a/bin/qtl-analysis
+++ b/bin/qtl-analysis
@@ -261,12 +261,12 @@ if [ -z "$dataset" ]; then
 fi
 
 # set input and output directories
-[ -z "$inputDir" ] && inputDir=$(pwd -P)/outfiles/$dataset/timeline_detectors
+[ -z "$inputDir" ] && inputDir=$(pwd -P)/outfiles/$dataset/timeline_detectors # set default `inputDir`
 [ ! -d $inputDir ] && printError "input directory $inputDir does not exist" && exit 100
-inputDir=$(realpath $inputDir)
-[ -z "$outputDir" ] && outputDir=$(pwd -P)/outfiles/$dataset
+inputDir=$(realpath $inputDir) # sanitize CLI argument's `intputDir`
+[ -z "$outputDir" ] && outputDir=$(pwd -P)/outfiles/$dataset # set default `outputDir`
 mkdir -p $outputDir
-outputDir=$(realpath $outputDir)
+outputDir=$(realpath $outputDir) # sanitize CLI argument's `outputDir`
 
 # set subdirectories
 finalDir=$outputDir/timeline_web

--- a/bin/qtl-analysis
+++ b/bin/qtl-analysis
@@ -264,7 +264,9 @@ fi
 [ -z "$inputDir" ] && inputDir=$(pwd -P)/outfiles/$dataset/timeline_detectors
 [ ! -d $inputDir ] && printError "input directory $inputDir does not exist" && exit 100
 inputDir=$(realpath $inputDir)
-[ -z "$outputDir" ] && outputDir=$(realpath $(pwd -P)/outfiles/$dataset) || outputDir=$(realpath $outputDir)
+[ -z "$outputDir" ] && outputDir=$(pwd -P)/outfiles/$dataset
+mkdir -p $outputDir
+outputDir=$(realpath $outputDir)
 
 # set subdirectories
 finalDir=$outputDir/timeline_web

--- a/bin/qtl-physics
+++ b/bin/qtl-physics
@@ -73,10 +73,13 @@ fi
 
 # set input and output directories
 [ -z "$dataset" ] && printError "data set not specified, use option '-d'" && exit 100
-[ -z "$inputDir" ] && inputDir=$(pwd -P)/outfiles/$dataset/timeline_physics
+[ -z "$inputDir" ] && inputDir=$(pwd -P)/outfiles/$dataset/timeline_physics # set default `inputDir`
 [ ! -d $inputDir ] && printError "input directory $inputDir does not exist" && exit 100
-inputDir=$(realpath $inputDir)
-[ -z "$outputDir" ] && outputDir=$(realpath $(pwd -P)/outfiles/$dataset) || outputDir=$(realpath $outputDir)
+inputDir=$(realpath $inputDir) # sanitize CLI argument's `inputDir`
+[ -z "$outputDir" ] && outputDir=$(pwd -P)/outfiles/$dataset # set default `outputDir`
+mkdir -p $outputDir
+outputDir=$(realpath $outputDir) # sanitize CLI argument's `outputDir`
+
 [ -z "$publishDir" ] && printError "need publishing directory, option '-p'" && exit 100
 
 # set subdirectories


### PR DESCRIPTION
If it doesn't exist, `realpath` will fail. Could also be fixed by `realpath -m`, but we are really only using `realpath` to sanitize custom output directory arguments (the default output directory already uses `$(pwd -P)`