### PR TITLE
fix: omit `ftof_ctof_vtdiff` timeline from RG-L

### DIFF
--- a/src/main/java/org/jlab/clas/timeline/run_analysis.groovy
+++ b/src/main/java/org/jlab/clas/timeline/run_analysis.groovy
@@ -215,7 +215,8 @@ fnames.sort().each{ fname ->
       if( timelineArg ==~ /^bmt.*/ ||
           timelineArg ==~ /^bst.*/ ||
           timelineArg ==~ /^cen.*/ ||
-          timelineArg ==~ /^cvt.*/ ) { allow_run = false }
+          timelineArg ==~ /^cvt.*/ ||
+          timelineArg == 'ftof_ctof_vtdiff' ) { allow_run = false }
     }
     else { // not RG-L
       if(timelineArg ==~ /^alert.*/) { allow_run = false }


### PR DESCRIPTION
Removes warning from step 2:
```
ftof_ctof_vtdiff.err:WARNING: no data for this timeline, not producing
```
This timeline has not been being produced in RG-L, but let's get rid of the warning too, to avoid confusion.
