### PR TITLE
fix: increase maximum heap size to 2 GB

### DIFF
--- a/libexec/environ.sh
+++ b/libexec/environ.sh
@@ -24,7 +24,7 @@ fi
 timeline_java_opts=(
   -cp "$TIMELINESRC/target/*:$TIMELINESRC/target/dependency/*"
   -Djava.util.logging.config.file=$TIMELINESRC/data/logging/$log_config.properties
-  -Xmx1536m
+  -Xmx2048m
   -XX:+UseSerialGC
   -Djava.awt.headless=true
 )


### PR DESCRIPTION
RG-L is experiencing OOM failures for `epics_xy`. If increasing the heap space limit doesn't fix this, we'll look into downsampling the `mya` payload.