### PR TITLE
fix(build): remove unused `release` property from POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,6 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <release>21</release>
   </properties>
 
   <repositories>


### PR DESCRIPTION
This variable is unused. The Java version is already correctly specified in the `maven-compiler-plugin` configuration.