### PR TITLE
feat: add zero padding for readability in the front end

### DIFF
--- a/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_ahdc_adc.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_ahdc_adc.groovy
@@ -25,7 +25,7 @@ int number_of_wires_per_timeline;
   }
 
   def getName() {
-    return "${this.class.simpleName}_${layer}"
+    return "${this.class.simpleName}_${layer_number}"
   }
 
   def processRun(dir, run) {
@@ -36,16 +36,16 @@ int number_of_wires_per_timeline;
     // data[run].put('bits',  trigger)
     float integral = 0;
     (1..number_of_wires_this_layer).collect{wire_number->
-      def h1 = dir.getObject(String.format('/ALERT/ADC_layer%d_wire_number%d', layer, wire_number))
+      def h1 = dir.getObject(String.format('/ALERT/ADC_layer%d_wire_number%02d', layer_number, wire_number))
       if(h1!=null) {
         if (h1.getBinContent(h1.getMaximumBin()) > 30 && h1.getEntries()>300){
-          data[run].put(String.format('ahdc_adc_layer%d_wire_number%d', layer, wire_number),  h1)
+          data[run].put(String.format('ahdc_adc_layer%d_wire_number%02d', layer_number, wire_number),  h1)
           integral = h1.integral()
           // def f1 = ALERTFitter.totfitter(h1)
-          // data[run].put(String.format('fit_adc_layer%d_wire_number%d', layer, wire_number),  f1)
-          // data[run].put(String.format('peak_location_ahdc_adc_layer%d_wire_number%d', layer, wire_number),  peak_location)
-          // data[run].put(String.format('sigma_adc_layer%d_wire_number%d', layer, wire_number),  f1.getParameter(2).abs())
-          data[run].put(String.format('integral_normalized_to_trigger_ahdc_adc_layer%d_wire_number%d', layer, wire_number),  integral/trigger.getBinContent(reference_trigger_bit) )
+          // data[run].put(String.format('fit_adc_layer%d_wire_number%02d', layer_number, wire_number),  f1)
+          // data[run].put(String.format('peak_location_ahdc_adc_layer%d_wire_number%02d', layer_number, wire_number),  peak_location)
+          // data[run].put(String.format('sigma_adc_layer%d_wire_number%02d', layer_number, wire_number),  f1.getParameter(2).abs())
+          data[run].put(String.format('integral_normalized_to_trigger_ahdc_adc_layer%d_wire_number%02d', layer_number, wire_number),  integral/trigger.getBinContent(reference_trigger_bit) )
           has_data.set(true)
         }
       }
@@ -72,10 +72,10 @@ int number_of_wires_per_timeline;
         (1..number_of_wires_this_timeline).collect{wire_index->
           def wire_number = wire_index + 15* timeline_index
           if (wire_number <= number_of_wires_this_layer){
-            def name = String.format('ahdc_adc_layer%d_wire_number%d', layer, wire_number)
+            def name = String.format('ahdc_adc_layer%d_wire_number%02d', layer_number, wire_number)
             def gr = new GraphErrors(name)
-            gr.setTitle(  String.format("AHDC ADC %s layer %d", variable.replace('_', ' '), layer))
-            gr.setTitleY( String.format("AHDC ADC %s layer %d", variable.replace('_', ' '), layer))
+            gr.setTitle(  String.format("AHDC ADC %s layer %d", variable.replace('_', ' '), layer_number))
+            gr.setTitleY( String.format("AHDC ADC %s layer %d", variable.replace('_', ' '), layer_number))
             gr.setTitleX("run number")
             data.sort{it.key}.each{run,it->
               out.mkdir('/'+it.run)
@@ -91,7 +91,7 @@ int number_of_wires_per_timeline;
             out.addDataSet(gr)
           }
         }
-        out.writeFile(String.format('alert_ahdc_adc_%s_layer%d_%d.hipo', variable, layer, timeline_index))
+        out.writeFile(String.format('alert_ahdc_adc_%s_layer%d_%d.hipo', variable, layer_number, timeline_index))
       }
     }
   }

--- a/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_ahdc_time.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_ahdc_time.groovy
@@ -25,7 +25,7 @@ int number_of_wires_per_timeline;
   }
   
   def getName() {
-    return "${this.class.simpleName}_${layer}"
+    return "${this.class.simpleName}_${layer_number}"
   }
 
   def processRun(dir, run) {
@@ -36,10 +36,10 @@ int number_of_wires_per_timeline;
     // data[run].put('bits',  trigger)
     float integral = 0;
     (1..number_of_wires_this_layer).collect{wire_number->
-      def h1 = dir.getObject(String.format("/ALERT/AHDC_TIME_layer%d_wire_number%d", layer, wire_number))
+      def h1 = dir.getObject(String.format("/ALERT/AHDC_TIME_layer%d_wire_number%02d", layer_number, wire_number))
       if(h1!=null) {
         if (h1.getBinContent(h1.getMaximumBin()) > 30 && h1.getEntries()>300){
-          data[run].put(String.format('ahdc_time_layer%d_wire_number%d', layer, wire_number),  h1)
+          data[run].put(String.format('ahdc_time_layer%d_wire_number%02d', layer_number, wire_number),  h1)
           def maxz = h1.getBinContent(h1.getMaximumBin());
           //int t0bin = (0..<h1.getMaximumBin()).find {
           //  h1.getBinContent(it) >= 0.25 * maxz
@@ -53,12 +53,12 @@ int number_of_wires_per_timeline;
           }
           float tmax = h1.getAxis().getBinCenter(tmaxbin)
           float width = tmax - t0
-          data[run].put(String.format('t0_ahdc_time_layer%d_wire_number%d', layer, wire_number),  t0)
-          data[run].put(String.format('tmax_ahdc_time_layer%d_wire_number%d', layer, wire_number),  tmax)
-          data[run].put(String.format('width_ahdc_time_layer%d_wire_number%d', layer, wire_number),  width)
-          data[run].put(String.format('fit_t0_ahdc_time_layer%d_wire_number%d', layer, wire_number),  ALERTFitter.time_fitter_rising(h1, t0))
-          data[run].put(String.format('fit_tmax_ahdc_time_layer%d_wire_number%d', layer, wire_number),  ALERTFitter.time_fitter_falling(h1, tmax))
-          data[run].put(String.format('fit_width_ahdc_time_layer%d_wire_number%d', layer, wire_number),  ALERTFitter.time_fitter_width(h1, t0, tmax))
+          data[run].put(String.format('t0_ahdc_time_layer%d_wire_number%02d', layer_number, wire_number),  t0)
+          data[run].put(String.format('tmax_ahdc_time_layer%d_wire_number%02d', layer_number, wire_number),  tmax)
+          data[run].put(String.format('width_ahdc_time_layer%d_wire_number%02d', layer_number, wire_number),  width)
+          data[run].put(String.format('fit_t0_ahdc_time_layer%d_wire_number%02d', layer_number, wire_number),  ALERTFitter.time_fitter_rising(h1, t0))
+          data[run].put(String.format('fit_tmax_ahdc_time_layer%d_wire_number%02d', layer_number, wire_number),  ALERTFitter.time_fitter_falling(h1, tmax))
+          data[run].put(String.format('fit_width_ahdc_time_layer%d_wire_number%02d', layer_number, wire_number),  ALERTFitter.time_fitter_width(h1, t0, tmax))
           has_data.set(true)
         }
       }
@@ -85,10 +85,10 @@ int number_of_wires_per_timeline;
         (1..number_of_wires_this_timeline).collect{wire_index->
           def wire_number = wire_index + 15* timeline_index
           if (wire_number <= number_of_wires_this_layer){
-            def name = String.format('ahdc_time_layer%d_wire_number%d', layer, wire_number)
+            def name = String.format('ahdc_time_layer%d_wire_number%02d', layer_number, wire_number)
             def gr = new GraphErrors(name)
-            gr.setTitle(  String.format("AHDC Time %s Layer %d", variable.replace('_', ' '), layer))
-            gr.setTitleY( String.format("AHDC Time %s Layer %d", variable.replace('_', ' '), layer))
+            gr.setTitle(  String.format("AHDC Time %s Layer %d", variable.replace('_', ' '), layer_number))
+            gr.setTitleY( String.format("AHDC Time %s Layer %d", variable.replace('_', ' '), layer_number))
             gr.setTitleX("run number")
             data.sort{it.key}.each{run,it->
               out.mkdir('/'+it.run)
@@ -104,7 +104,7 @@ int number_of_wires_per_timeline;
             out.addDataSet(gr)
           }
         }
-        out.writeFile(String.format('alert_ahdc_time_%s_layer%d_%d.hipo', variable, layer, timeline_index))
+        out.writeFile(String.format('alert_ahdc_time_%s_layer%d_%d.hipo', variable, layer_number, timeline_index))
       }
     }
   }

--- a/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_atof_time.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_atof_time.groovy
@@ -20,7 +20,7 @@ int max_index;
   }
   
   def getName() {
-    return "${this.class.simpleName}_${sector}"
+    return "${this.class.simpleName}_${String.format('%02d', sector)}"
   }
 
   def processRun(dir, run) {
@@ -34,7 +34,7 @@ int max_index;
       assert sector == atof_sector // sanity-check. this should be the same.
       int layer     = (index % (11 * 4)) / 11;
       int component = index % 11;
-      def file_index = String.format('sector%d_layer%d_component%d', sector, layer, component)
+      def file_index = String.format('sector%02d_layer%d_component%02d', sector, layer, component)
       def h1 = dir.getObject(String.format('/ALERT/ATOF_Time_%s', file_index))
       if(h1!=null) {
         if (h1.getBinContent(h1.getMaximumBin()) > 30 && h1.getEntries()>300){
@@ -66,13 +66,13 @@ int max_index;
         out.mkdir('/timelines')
         (0..<11).collect{component->
           def file_index = ''
-           file_index = String.format('sector%d_layer%d_component%d', sector, layer, component)
+           file_index = String.format('sector%02d_layer%d_component%02d', sector, layer, component)
           names << String.format('atof_time_%s', file_index)
         }
         names.each{ name ->
           def gr = new GraphErrors(name)
-          gr.setTitle(  String.format("ATOF Time %s sector %d layer %d", variable.replace('_', ' '), sector, layer))
-          gr.setTitleY( String.format("ATOF Time %s sector %d layer %d (ns)", variable.replace('_', ' '), sector, layer))
+          gr.setTitle(  String.format("ATOF Time %s sector %02d layer %d", variable.replace('_', ' '), sector, layer))
+          gr.setTitleY( String.format("ATOF Time %s sector %02d layer %d (ns)", variable.replace('_', ' '), sector, layer))
           gr.setTitleX("run number")
           data.sort{it.key}.each{run,it->
             out.mkdir('/'+it.run)
@@ -87,7 +87,7 @@ int max_index;
           out.cd('/timelines')
           out.addDataSet(gr)
         }
-        out.writeFile(String.format('alert_atof_time_%s_sector%d_layer%d.hipo', variable, sector, layer))
+        out.writeFile(String.format('alert_atof_time_%s_sector%02d_layer%d.hipo', variable, sector, layer))
       }
     }
   }

--- a/src/main/java/org/jlab/clas/timeline/histograms/ALERT.java
+++ b/src/main/java/org/jlab/clas/timeline/histograms/ALERT.java
@@ -68,7 +68,7 @@ public class ALERT {
       layer     = (index % (11 * 4)) / 11;
       component = index % 11;
 
-      ATOF_Time[index] = new H1F(String.format("ATOF_Time_sector%d_layer%d_component%d", sector, layer, component), String.format("ATOF Time sector%d layer%d component%d", sector, layer, component), 300, 85, 100);
+      ATOF_Time[index] = new H1F(String.format("ATOF_Time_sector%02d_layer%d_component%02d", sector, layer, component), String.format("ATOF Time sector%02d layer%d component%02d", sector, layer, component), 300, 85, 100);
       ATOF_Time[index].setTitleX("ATOF Time (ns)");
       ATOF_Time[index].setTitleY("Counts");
       ATOF_Time[index].setFillColor(4);
@@ -81,20 +81,22 @@ public class ALERT {
 
     for (int index = 0; index<576; index++) {
       int layer = 0;
+      int layer_number = 0;
       int wire_number = 0;
 
       for (int j=0; j<8; j++){
         if (index < layer_wires_cumulative[j+1]){
           layer = layer_encoding[j];
+          layer_number = j + 1;
           wire_number = index + 1 - layer_wires_cumulative[j];
           break;
         }
       }
-      ADC[index] = new H1F(String.format("ADC_layer%d_wire_number%d", layer, wire_number), String.format("ADC layer%d wire number%d", layer, wire_number), 516, 0.0, 3612.0);
+      ADC[index] = new H1F(String.format("ADC_layer%d_wire_number%02d", layer_number, wire_number), String.format("ADC layer%d wire number%02d", layer_number, wire_number), 516, 0.0, 3612.0);
       ADC[index].setTitleX("ADC");
       ADC[index].setTitleY("Counts");
       ADC[index].setFillColor(4);
-      AHDC_TIME[index] = new H1F(String.format("AHDC_TIME_layer%d_wire_number%d", layer, wire_number), String.format("AHDC Time layer %d wire number%d", layer, wire_number), 450, -10.f, 440.0f);
+      AHDC_TIME[index] = new H1F(String.format("AHDC_TIME_layer%d_wire_number%02d", layer_number, wire_number), String.format("AHDC Time layer %d wire number%02d", layer_number, wire_number), 450, -10.f, 440.0f);
       AHDC_TIME[index].setTitleX("AHDC TIME (ns)");
       AHDC_TIME[index].setTitleY("Counts");
       AHDC_TIME[index].setFillColor(4);


### PR DESCRIPTION
Readability problem raised in the Issue #430 is solved by this PR that adds zero padding in the ATOF sector number. Also padded AHDC wire number. Switched AHDC layer encoding from superlayer to layer.

Results:

<img width="1111" height="124" alt="Screen Shot 2025-12-17 at 4 18 10 PM" src="https://github.com/user-attachments/assets/99d499ea-7ecc-4ec0-b529-39efbb2ab72a" />

<img width="484" height="466" alt="Screen Shot 2025-12-17 at 4 17 58 PM" src="https://github.com/user-attachments/assets/b9c836f0-ce9e-44a8-be71-a28d967b3af1" />
