### PR TITLE
build: enable `failOnWarning`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <configuration>
           <release>21</release>
           <compilerId>groovy-eclipse-compiler</compilerId>
+          <failOnWarning>true</failOnWarning>
         </configuration>
         <dependencies>
           <!-- https://groovy.jfrog.io/ui/native/plugins-release/org/codehaus/groovy/groovy-eclipse-compiler/ -->

--- a/src/main/java/org/jlab/clas/timeline/histograms/ALERT.java
+++ b/src/main/java/org/jlab/clas/timeline/histograms/ALERT.java
@@ -80,13 +80,11 @@ public class ALERT {
     AHDC_TIME     = new H1F[576];
 
     for (int index = 0; index<576; index++) {
-      int layer = 0;
       int layer_number = 0;
       int wire_number = 0;
 
       for (int j=0; j<8; j++){
         if (index < layer_wires_cumulative[j+1]){
-          layer = layer_encoding[j];
           layer_number = j + 1;
           wire_number = index + 1 - layer_wires_cumulative[j];
           break;


### PR DESCRIPTION
- compilation will now fail on warnings (apologies for being so strict, but we managed to get down to zero warnings, so it would be great to try to keep it that way)
- removed the unused `layer` variable from `ALERT.java`