### PR TITLE
fix(slurm): request minimal `/scratch` allocation

### DIFF
--- a/bin/qtl-histogram
+++ b/bin/qtl-histogram
@@ -8,6 +8,7 @@ source $(dirname $0)/../libexec/environ.sh
 # constants ############################################################
 # slurm settings
 SLURM_MEMORY=2000 # must be more than max heap size in $TIMELINE_JAVA_OPTS
+SLURM_DISK=32M
 SLURM_TIME=10:00:00
 SLURM_LOG=/farm_out/%u/%x-%A_%a
 ########################################################################
@@ -489,6 +490,7 @@ for key in ${jobkeys[@]}; do
 #SBATCH --account=clas12
 
 #SBATCH --mem-per-cpu=$SLURM_MEMORY
+#SBATCH --gres=disk:$SLURM_DISK
 #SBATCH --time=$SLURM_TIME
 
 #SBATCH --array=1-$(cat $joblist | wc -l)

--- a/bin/qtl-reheat
+++ b/bin/qtl-reheat
@@ -6,6 +6,7 @@ source $(dirname $0)/../libexec/environ.sh
 # constants ############################################################
 # slurm settings
 SLURM_MEMORY=2000 # must be more than max heap size `java` calls
+SLURM_DISK=32M
 SLURM_TIME=12:00:00
 SLURM_LOG=/farm_out/%u/%x-%A_%a
 # reheating methods: name -> description
@@ -189,6 +190,7 @@ cat > $slurmScript << EOF
 #SBATCH --partition=production
 #SBATCH --account=clas12
 #SBATCH --mem-per-cpu=$SLURM_MEMORY
+#SBATCH --gres=disk:$SLURM_DISK
 #SBATCH --time=$SLURM_TIME
 #SBATCH --array=1-$(cat $jobList | wc -l)
 #SBATCH --ntasks=1


### PR DESCRIPTION
From SciComp:

> Slurm users: By default, Slurm jobs receive no /scratch allocation. If
> your job runs entirely in memory and shared filesystems, this may be
> fine. However, many applications implicitly use temporary scratch space.
> If you encounter ENOSPC errors, you will need to request disk
> explicitly, for example:
>
> ```
> #SBATCH --gres=disk:1G
> ```

At least `module switch coatjava` has triggered 'no space left on device' errors, so let's request a bit of space. 32 MB should be way more than needed, but is also still very minimal, hopefully.