### PR TITLE
feat: change ATOF time window to -5,5

### DIFF
--- a/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_atof_time.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_atof_time.groovy
@@ -24,7 +24,7 @@ def has_data = new AtomicBoolean(false)
           data[run].put(String.format('atof_time_%02d', component),  h1)
           def f1 = ALERTFitter.atof_time_fitter(h1,component)
           data[run].put(String.format('fit_atof_time_%02d', component),  f1)
-          data[run].put(String.format('peak_location_atof_time_%02d', component),  f1.getParameter(1).abs())
+          data[run].put(String.format('peak_location_atof_time_%02d', component),  f1.getParameter(1))
           data[run].put(String.format('sigma_atof_time_%02d', component),  f1.getParameter(2).abs())
           has_data.set(true)
         }

--- a/src/main/java/org/jlab/clas/timeline/histograms/ALERT.java
+++ b/src/main/java/org/jlab/clas/timeline/histograms/ALERT.java
@@ -61,7 +61,7 @@ public class ALERT {
 
     for (int component = 0; component < 11; component++) {
 
-      ATOF_Time[component] = new H1F(String.format("ATOF_Time_component%02d", component), String.format("ATOF Time component%02d", component), 240, 83, 95);
+      ATOF_Time[component] = new H1F(String.format("ATOF_Time_component%02d", component), String.format("ATOF Time component%02d", component), 200, -5, 5);
       ATOF_Time[component].setTitleX("ATOF Time (ns)");
       ATOF_Time[component].setTitleY("Counts");
       ATOF_Time[component].setFillColor(4);


### PR DESCRIPTION
With the new CJ version, our ATOF time window is now (-5,5).
We changed the following:

- Move the ATOF histogram range to (-5,5), previously was at (83,95)
- Removed the .abs() from f1.getParameter(1) to include peaks at negative.