### PR TITLE
feat: update ATOF z histogram fitting range

### DIFF
--- a/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_atof_z.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_atof_z.groovy
@@ -31,7 +31,7 @@ class alert_atof_z {
     def name = 'atof_z_combined'
     def gr = new GraphErrors(name)
     gr.setTitle("ATOF z RMS")
-    gr.setTitleY("ATOF z RMS (cm)")
+    gr.setTitleY("ATOF z RMS (mm)")
     gr.setTitleX("run number")
     data.sort { it.key }.each { run, it ->
       out.mkdir('/' + it.run)

--- a/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_atof_z_c4.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_atof_z_c4.groovy
@@ -36,7 +36,7 @@ class alert_atof_z_c4 {
       def name = 'atof_z_c4_combined'
       def gr = new GraphErrors(name)
       gr.setTitle(String.format("ATOF z c4 %s", variable.replace('_', ' ')))
-      gr.setTitleY(String.format("ATOF z c4 %s (cm)", variable.replace('_', ' ')))
+      gr.setTitleY(String.format("ATOF z c4 %s (mm)", variable.replace('_', ' ')))
       gr.setTitleX("run number")
       data.sort { it.key }.each { run, it ->
         out.mkdir('/' + it.run)

--- a/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_atof_z_c4_sl.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_atof_z_c4_sl.groovy
@@ -48,7 +48,7 @@ class alert_atof_z_c4_sl {
       def name = String.format('atof_z_c4_sl_s%02d_l%d', sector, layer)
       def gr = new GraphErrors(name)
       gr.setTitle(String.format("ATOF z c4 %s Sector %02d Layer %d", variable.replace('_', ' '), sector, layer))
-      gr.setTitleY(String.format("ATOF z c4 %s (cm)", variable.replace('_', ' ')))
+      gr.setTitleY(String.format("ATOF z c4 %s (mm)", variable.replace('_', ' ')))
       gr.setTitleX("run number")
       data.sort { it.key }.each { run, it ->
         out.mkdir('/' + it.run)

--- a/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_atof_z_sl.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_atof_z_sl.groovy
@@ -43,7 +43,7 @@ class alert_atof_z_sl {
     def name = String.format('atof_z_sl_s%02d_l%d', sector, layer)
     def gr = new GraphErrors(name)
     gr.setTitle(String.format("ATOF z RMS Sector %02d Layer %d", sector, layer))
-    gr.setTitleY("ATOF z RMS (cm)")
+    gr.setTitleY("ATOF z RMS (mm)")
     gr.setTitleX("run number")
     data.sort { it.key }.each { run, it ->
       out.mkdir('/' + it.run)

--- a/src/main/java/org/jlab/clas/timeline/fitter/ALERTFitter.groovy
+++ b/src/main/java/org/jlab/clas/timeline/fitter/ALERTFitter.groovy
@@ -185,10 +185,10 @@ class ALERTFitter{
 	static F1D atof_z_fitter(H1F h1){
 		double maxz = h1.getBinContent(h1.getMaximumBin())
 		double peak = h1.getAxis().getBinCenter(h1.getMaximumBin())
-		int bin_low  = h1.getAxis().getBin(peak - 10.0)
-		int bin_high = h1.getAxis().getBin(peak + 10.0)
+		int bin_low  = h1.getAxis().getBin(peak - 100.0)
+		int bin_high = h1.getAxis().getBin(peak + 100.0)
 		double sigma = ALERTFitter.getRestrictedRMS(h1, bin_low, bin_high)
-		if (sigma <= 0 || Double.isNaN(sigma)) sigma = 5.0
+		if (sigma <= 0 || Double.isNaN(sigma)) sigma = 100.0
 
 		def f1 = new F1D("fit:" + h1.getName(), "[amp]*gaus(x,[mean],[sigma])", peak - 2*sigma, peak + 2*sigma)
 		f1.setLineColor(33)
@@ -198,8 +198,8 @@ class ALERTFitter{
 		f1.setParameter(1, peak)
 		f1.setParameter(2, sigma)
 		if (maxz > 0) f1.setParLimits(0, maxz * 0.5, maxz * 1.5)
-		f1.setParLimits(1, peak - 5.0, peak + 5.0)
-		f1.setParLimits(2, 0.01, 10.0)
+		f1.setParLimits(1, peak - 50.0, peak + 50.0)
+		f1.setParLimits(2, 0.01, 100.0)
 
 		PrintStream original = System.out
 		System.setOut(new PrintStream(OutputStream.nullOutputStream()))

--- a/src/main/java/org/jlab/clas/timeline/histograms/ALERT.java
+++ b/src/main/java/org/jlab/clas/timeline/histograms/ALERT.java
@@ -71,23 +71,23 @@ public class ALERT {
       ATOF_Time[component].setFillColor(4);
     }
       ATOF_z[0]= new H1F(String.format("ATOF_z_combined"), String.format("ATOF z"), 300,-300,300);
-      ATOF_z[0].setTitleX("ATOF z (ns)");
+      ATOF_z[0].setTitleX("ATOF z (mm)");
       ATOF_z[0].setTitleY("Counts");
       ATOF_z[0].setFillColor(4);
       ATOF_z_c4[0]= new H1F(String.format("ATOF_z_combined_c4"), String.format("ATOF z with c4"), 300,-300,300);
-      ATOF_z_c4[0].setTitleX("ATOF z (ns)");
+      ATOF_z_c4[0].setTitleX("ATOF z (mm)");
       ATOF_z_c4[0].setTitleY("Counts");
       ATOF_z_c4[0].setFillColor(4);
     for(int sector=0;sector<15;sector++){
           for(int layer=0;layer<4;layer++){
               int gsector=sector*4+layer;
               ATOF_z_sl[gsector] = new H1F(String.format("ATOF_z_sector%02d_layer%02d", sector,layer), String.format("ATOF z sector%02d layer %2d", sector,layer), 300,-300,300);
-              ATOF_z_sl[gsector].setTitleX("ATOF z (ns)");
+              ATOF_z_sl[gsector].setTitleX("ATOF z (mm)");
               ATOF_z_sl[gsector].setTitleY("Counts");
               ATOF_z_sl[gsector].setFillColor(4);
 
               ATOF_z_c4_sl[gsector] = new H1F(String.format("ATOF_z_c4_sector%02d_layer%02d", sector,layer), String.format("ATOF z with C4 sector%02d layer %2d", sector,layer), 300,-300,300);
-              ATOF_z_c4_sl[gsector].setTitleX("ATOF z (ns)");
+              ATOF_z_c4_sl[gsector].setTitleX("ATOF z (mm)");
               ATOF_z_c4_sl[gsector].setTitleY("Counts");
               ATOF_z_c4_sl[gsector].setFillColor(4);
               

--- a/src/main/java/org/jlab/clas/timeline/histograms/ALERT.java
+++ b/src/main/java/org/jlab/clas/timeline/histograms/ALERT.java
@@ -70,23 +70,23 @@ public class ALERT {
       ATOF_Time[component].setTitleY("Counts");
       ATOF_Time[component].setFillColor(4);
     }
-      ATOF_z[0]= new H1F(String.format("ATOF_z_combined"), String.format("ATOF z"), 250,-30,20);
+      ATOF_z[0]= new H1F(String.format("ATOF_z_combined"), String.format("ATOF z"), 300,-300,300);
       ATOF_z[0].setTitleX("ATOF z (ns)");
       ATOF_z[0].setTitleY("Counts");
       ATOF_z[0].setFillColor(4);
-      ATOF_z_c4[0]= new H1F(String.format("ATOF_z_combined_c4"), String.format("ATOF z with c4"), 250,-30,20);
+      ATOF_z_c4[0]= new H1F(String.format("ATOF_z_combined_c4"), String.format("ATOF z with c4"), 300,-300,300);
       ATOF_z_c4[0].setTitleX("ATOF z (ns)");
       ATOF_z_c4[0].setTitleY("Counts");
       ATOF_z_c4[0].setFillColor(4);
     for(int sector=0;sector<15;sector++){
           for(int layer=0;layer<4;layer++){
               int gsector=sector*4+layer;
-              ATOF_z_sl[gsector] = new H1F(String.format("ATOF_z_sector%02d_layer%02d", sector,layer), String.format("ATOF z sector%02d layer %2d", sector,layer), 250,-30,20);
+              ATOF_z_sl[gsector] = new H1F(String.format("ATOF_z_sector%02d_layer%02d", sector,layer), String.format("ATOF z sector%02d layer %2d", sector,layer), 300,-300,300);
               ATOF_z_sl[gsector].setTitleX("ATOF z (ns)");
               ATOF_z_sl[gsector].setTitleY("Counts");
               ATOF_z_sl[gsector].setFillColor(4);
 
-              ATOF_z_c4_sl[gsector] = new H1F(String.format("ATOF_z_c4_sector%02d_layer%02d", sector,layer), String.format("ATOF z with C4 sector%02d layer %2d", sector,layer), 250,-30,20);
+              ATOF_z_c4_sl[gsector] = new H1F(String.format("ATOF_z_c4_sector%02d_layer%02d", sector,layer), String.format("ATOF z with C4 sector%02d layer %2d", sector,layer), 300,-300,300);
               ATOF_z_c4_sl[gsector].setTitleX("ATOF z (ns)");
               ATOF_z_c4_sl[gsector].setTitleY("Counts");
               ATOF_z_c4_sl[gsector].setFillColor(4);


### PR DESCRIPTION
I found the unit was used wrongly for ATOF z histogram range. Change it from (-30,25) -> (-300,300) to match the [mm] unit.
- [x] Changed the ATOF z histogram fitting range, all axis labels. 
- [x] The test with p0v9 data shows correct peak location and RMS.

<img width="778" height="698" alt="Screenshot 2026-04-07 at 2 28 59 PM" src="https://github.com/user-attachments/assets/17c67b0f-df0e-416a-a7cb-496aafbcab83" />

