### PR TITLE
Modify forward electron Vz to add target window

### DIFF
--- a/src/main/java/org/jlab/clas/timeline/analysis/forward/forward_Tracking_EleVz.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/forward/forward_Tracking_EleVz.groovy
@@ -132,58 +132,32 @@ def write() {
     if (data_2nd_peak.size() != 0) {
       out.addDataSet(grtl_2nd_peak)
     }
-  }
 
-  out.writeFile('forward_electron_VZ.hipo')
-
-  if (data_upstream.size() != 0) {
-
-    TDirectory out_upstream = new TDirectory()
-    out_upstream.mkdir('/timelines')
-    (0..<6).each{ sec->
-      def grtl_upstream = new GraphErrors('sec'+(sec+1))
+    if (data_upstream.size() != 0) {
+      def grtl_upstream = new GraphErrors('sec'+(sec+1)+'_upstream')
       grtl_upstream.setTitle("VZ (upstream peak value) for electrons per sector")
       grtl_upstream.setTitleY("VZ (upstream peak value) for electrons per sector (cm)")
       grtl_upstream.setTitleX("run number")
 
-      data_upstream.sort{it.key}.each{run,it->
-        if (sec==0){
-          out_upstream.mkdir('/'+it.run)
-        }
-        out_upstream.cd('/'+it.run)
-        out_upstream.addDataSet(it.hlist[sec])
-        out_upstream.addDataSet(it.flist[sec])
-        grtl_upstream.addPoint(it.run, it.mean[sec], 0, 0)
-      }
-
-      out_upstream.cd('/timelines')
-      out_upstream.addDataSet(grtl_upstream)
-    }
-    out_upstream.writeFile('forward_electron_VZ_upstream.hipo')
-
-    TDirectory out_window = new TDirectory()
-    out_window.mkdir('/timelines')
-    (0..<6).each{ sec->
-      def grtl_window = new GraphErrors('sec'+(sec+1))
+      def grtl_window = new GraphErrors('sec'+(sec+1)+'_window')
       grtl_window.setTitle("VZ target window length (downstream - upstream peak distance) per sector")
       grtl_window.setTitleY("VZ target window length (cm)")
       grtl_window.setTitleX("run number")
 
       data_upstream.sort{it.key}.each{run,it->
-        if (sec==0){
-          out_window.mkdir('/'+it.run)
-        }
-        out_window.cd('/'+it.run)
-        out_window.addDataSet(it.hlist[sec])
+        out.cd('/'+it.run)
+        out.addDataSet(it.flist[sec])
+        grtl_upstream.addPoint(it.run, it.mean[sec], 0, 0)
         def window_length = (data[run].mean[sec] - it.mean[sec]).abs()
         grtl_window.addPoint(it.run, window_length, 0, 0)
       }
 
-      out_window.cd('/timelines')
-      out_window.addDataSet(grtl_window)
+      out.cd('/timelines')
+      out.addDataSet(grtl_upstream)
+      out.addDataSet(grtl_window)
     }
-    out_window.writeFile('forward_electron_VZ_target_window_length.hipo')
-
   }
+
+  out.writeFile('forward_electron_VZ.hipo')
 }
 }

--- a/src/main/java/org/jlab/clas/timeline/analysis/forward/forward_Tracking_EleVz.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/forward/forward_Tracking_EleVz.groovy
@@ -9,6 +9,7 @@ class forward_Tracking_EleVz {
 
 def data = new ConcurrentHashMap()
 def data_2nd_peak = new ConcurrentHashMap()
+def data_upstream = new ConcurrentHashMap()
 
 def is_RGD_LD2 = { run ->
   return (RunDependentCut.runIsInRange(run, 18305, 18313, true) ||
@@ -31,6 +32,11 @@ def processRun(dir, run) {
   def meanlist_2nd_peak = []
   def sigmalist_2nd_peak = []
   def chi2list_2nd_peak = []
+
+  def funclist_upstream = []
+  def meanlist_upstream = []
+  def sigmalist_upstream = []
+  def chi2list_upstream = []
 
   def histlist =   (0..<6).collect{
     def h1 = dir.getObject('/elec/H_trig_vz_mom_S'+(it+1)).projectionY()
@@ -56,7 +62,12 @@ def processRun(dir, run) {
       }
     }
     else if (dataset == 'rgl') {
-      f1 = ForwardFitter.fitRGL(h1)
+      f1 = ForwardFitter.fitRGL(h1, 10, 30)
+      def f1_upstream = ForwardFitter.fitRGL(h1, -40, -20)
+      funclist_upstream.add(f1_upstream)
+      meanlist_upstream.add(f1_upstream.getParameter(1))
+      sigmalist_upstream.add(f1_upstream.getParameter(2).abs())
+      chi2list_upstream.add(f1_upstream.getChiSquare())
     }
     else {
       f1 = ForwardFitter.fit(h1)
@@ -79,6 +90,9 @@ def processRun(dir, run) {
   data[run] = [run:run, hlist:histlist, flist:funclist, mean:meanlist, sigma:sigmalist, clist:chi2list]
   if (funclist_2nd_peak.size() > 0) {
     data_2nd_peak[run] = [run:run, hlist:histlist, flist:funclist_2nd_peak, mean:meanlist_2nd_peak, sigma:sigmalist_2nd_peak, clist:chi2list_2nd_peak]
+  }
+  if (funclist_upstream.size() > 0) {
+    data_upstream[run] = [run:run, hlist:histlist, flist:funclist_upstream, mean:meanlist_upstream, sigma:sigmalist_upstream, clist:chi2list_upstream]
   }
 }
 
@@ -121,5 +135,55 @@ def write() {
   }
 
   out.writeFile('forward_electron_VZ.hipo')
+
+  if (data_upstream.size() != 0) {
+
+    TDirectory out_upstream = new TDirectory()
+    out_upstream.mkdir('/timelines')
+    (0..<6).each{ sec->
+      def grtl_upstream = new GraphErrors('sec'+(sec+1))
+      grtl_upstream.setTitle("VZ (upstream peak value) for electrons per sector")
+      grtl_upstream.setTitleY("VZ (upstream peak value) for electrons per sector (cm)")
+      grtl_upstream.setTitleX("run number")
+
+      data_upstream.sort{it.key}.each{run,it->
+        if (sec==0){
+          out_upstream.mkdir('/'+it.run)
+        }
+        out_upstream.cd('/'+it.run)
+        out_upstream.addDataSet(it.hlist[sec])
+        out_upstream.addDataSet(it.flist[sec])
+        grtl_upstream.addPoint(it.run, it.mean[sec], 0, 0)
+      }
+
+      out_upstream.cd('/timelines')
+      out_upstream.addDataSet(grtl_upstream)
+    }
+    out_upstream.writeFile('forward_electron_VZ_upstream.hipo')
+
+    TDirectory out_window = new TDirectory()
+    out_window.mkdir('/timelines')
+    (0..<6).each{ sec->
+      def grtl_window = new GraphErrors('sec'+(sec+1))
+      grtl_window.setTitle("VZ target window length (downstream - upstream peak distance) per sector")
+      grtl_window.setTitleY("VZ target window length (cm)")
+      grtl_window.setTitleX("run number")
+
+      data_upstream.sort{it.key}.each{run,it->
+        if (sec==0){
+          out_window.mkdir('/'+it.run)
+        }
+        out_window.cd('/'+it.run)
+        out_window.addDataSet(it.hlist[sec])
+        def window_length = (data[run].mean[sec] - it.mean[sec]).abs()
+        grtl_window.addPoint(it.run, window_length, 0, 0)
+      }
+
+      out_window.cd('/timelines')
+      out_window.addDataSet(grtl_window)
+    }
+    out_window.writeFile('forward_electron_VZ_target_window_length.hipo')
+
+  }
 }
 }

--- a/src/main/java/org/jlab/clas/timeline/analysis/forward/forward_Tracking_NegVz.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/forward/forward_Tracking_NegVz.groovy
@@ -55,7 +55,7 @@ def processRun(dir, run) {
       }
     }
     else if (dataset == 'rgl') {
-      f1 = ForwardFitter.fitRGL(h1)
+      f1 = ForwardFitter.fitRGL(h1, 10, 30)
     }
     else {
       f1 = ForwardFitter.fit(h1)

--- a/src/main/java/org/jlab/clas/timeline/analysis/forward/forward_Tracking_PosVz.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/forward/forward_Tracking_PosVz.groovy
@@ -55,7 +55,7 @@ def processRun(dir, run) {
       }
     }
     else if (dataset == 'rgl') {
-      f1 = ForwardFitter.fitRGL(h1)
+      f1 = ForwardFitter.fitRGL(h1, 10, 30)
     }
     else {
       f1 = ForwardFitter.fit(h1)

--- a/src/main/java/org/jlab/clas/timeline/fitter/ForwardFitter.groovy
+++ b/src/main/java/org/jlab/clas/timeline/fitter/ForwardFitter.groovy
@@ -55,12 +55,15 @@ class ForwardFitter{
   static F1D fitRGL(H1F h1, double fit_left, double fit_right) {
     def f1 = new F1D("fit:"+h1.getName(), "[amp]*gaus(x,[mean],[sigma])", fit_left, fit_right);
 
-    // zoom in to [fit_left, fit_right] to find local max, avoiding the other peak
-    int nBins = h1.getAxis().getNBins()
-    h1.getAxis().setRangeUser(fit_left, fit_right)
-    double hAmp  = h1.getBinContent(h1.getMaximumBin())
-    double hMean = h1.getAxis().getBinCenter(h1.getMaximumBin())
-    h1.getAxis().setRange(0, nBins + 1)  // restore full range
+    // find local max within [fit_left, fit_right] only, avoiding the other peak
+    int binLeft  = Math.max(0, h1.getAxis().getBin(fit_left))
+    int binRight = Math.min(h1.getAxis().getNBins() - 1, h1.getAxis().getBin(fit_right))
+    int maxBin = binLeft
+    for (int i = binLeft + 1; i <= binRight; i++) {
+      if (h1.getBinContent(i) > h1.getBinContent(maxBin)) maxBin = i
+    }
+    double hAmp  = h1.getBinContent(maxBin)
+    double hMean = h1.getAxis().getBinCenter(maxBin)
 
     f1.setRange(hMean - 2.0, hMean + 2.0);
     f1.setParameter(0, hAmp);

--- a/src/main/java/org/jlab/clas/timeline/fitter/ForwardFitter.groovy
+++ b/src/main/java/org/jlab/clas/timeline/fitter/ForwardFitter.groovy
@@ -68,7 +68,7 @@ class ForwardFitter{
     f1.setRange(hMean - 2.0, hMean + 2.0);
     f1.setParameter(0, hAmp);
     f1.setParameter(1, hMean);
-    f1.setParameter(2, 0.3);
+    f1.setParameter(2, 1);
     MoreFitter.fit(f1,h1,"LQ");
 
     def makefit = {func->

--- a/src/main/java/org/jlab/clas/timeline/fitter/ForwardFitter.groovy
+++ b/src/main/java/org/jlab/clas/timeline/fitter/ForwardFitter.groovy
@@ -52,22 +52,25 @@ class ForwardFitter{
   }
 
 
-  static F1D fitRGL(H1F h1) {
-    def f1 = new F1D("fit:"+h1.getName(), "[amp]*gaus(x,[mean],[sigma])", 15, 25);
-    double hAmp  = h1.getBinContent(h1.getMaximumBin());
-    double hMean = h1.getAxis().getBinCenter(h1.getMaximumBin());
-    double hRMS  = h1.getRMS(); //cm
-    f1.setRange(hMean-1.0, hMean+1.0);
+  static F1D fitRGL(H1F h1, double fit_left, double fit_right) {
+    def f1 = new F1D("fit:"+h1.getName(), "[amp]*gaus(x,[mean],[sigma])", fit_left, fit_right);
+
+    // zoom in to [fit_left, fit_right] to find local max, avoiding the other peak
+    int nBins = h1.getAxis().getNBins()
+    h1.getAxis().setRangeUser(fit_left, fit_right)
+    double hAmp  = h1.getBinContent(h1.getMaximumBin())
+    double hMean = h1.getAxis().getBinCenter(h1.getMaximumBin())
+    h1.getAxis().setRange(0, nBins + 1)  // restore full range
+
+    f1.setRange(hMean - 2.0, hMean + 2.0);
     f1.setParameter(0, hAmp);
     f1.setParameter(1, hMean);
-    //f1.setParameter(2, hRMS);
     f1.setParameter(2, 0.3);
     MoreFitter.fit(f1,h1,"LQ");
 
     def makefit = {func->
       hMean = func.getParameter(1)
-      hRMS = func.getParameter(2).abs()
-      func.setRange(hMean-1.0,hMean+1.0)
+      func.setRange(hMean - 2.0, hMean + 2.0)
       MoreFitter.fit(func,h1,"LQ")
       return [func.getChiSquare(), (0..<func.getNPars()).collect{func.getParameter(it)}]
     }
@@ -75,7 +78,6 @@ class ForwardFitter{
     def fits1 = (0..20).collect{makefit(f1)}
     def bestfit = fits1.sort()[0]
     f1.setParameters(*bestfit[1])
-    //makefit(f1)
 
     return f1
   }

--- a/src/main/java/org/jlab/clas/timeline/histograms/GeneralMon.java
+++ b/src/main/java/org/jlab/clas/timeline/histograms/GeneralMon.java
@@ -1250,7 +1250,7 @@ public class GeneralMon {
       H_trig_theta_phi_S[s].setTitle(String.format("e sect %d",s+1));
       H_trig_theta_phi_S[s].setTitleX("#phi (^o)");
       H_trig_theta_phi_S[s].setTitleY("#theta (^o)");
-      H_trig_vz_mom_S[s] = new H2F(String.format("H_trig_vz_mom_S%d",s+1),String.format("H_trig_vz_mom_S%d",s+1),100,0,EB,100,-25,50);
+      H_trig_vz_mom_S[s] = new H2F(String.format("H_trig_vz_mom_S%d",s+1),String.format("H_trig_vz_mom_S%d",s+1),100,0,EB,100,-50,50);
       H_trig_vz_mom_S[s].setTitle(String.format("e sect %d",s+1));
       H_trig_vz_mom_S[s].setTitleX("p (GeV)");
       H_trig_vz_mom_S[s].setTitleY("vz (cm)");

--- a/src/main/java/org/jlab/clas/timeline/histograms/GeneralMon.java
+++ b/src/main/java/org/jlab/clas/timeline/histograms/GeneralMon.java
@@ -1250,7 +1250,7 @@ public class GeneralMon {
       H_trig_theta_phi_S[s].setTitle(String.format("e sect %d",s+1));
       H_trig_theta_phi_S[s].setTitleX("#phi (^o)");
       H_trig_theta_phi_S[s].setTitleY("#theta (^o)");
-      H_trig_vz_mom_S[s] = new H2F(String.format("H_trig_vz_mom_S%d",s+1),String.format("H_trig_vz_mom_S%d",s+1),100,0,EB,100,-50,50);
+      H_trig_vz_mom_S[s] = new H2F(String.format("H_trig_vz_mom_S%d",s+1),String.format("H_trig_vz_mom_S%d",s+1),100,0,EB,200,-50,50);
       H_trig_vz_mom_S[s].setTitle(String.format("e sect %d",s+1));
       H_trig_vz_mom_S[s].setTitleX("p (GeV)");
       H_trig_vz_mom_S[s].setTitleY("vz (cm)");


### PR DESCRIPTION
- [x] Add for RGL only: the timeline upstream peak fit (-40,-10), change the rgl-fit function ForwardFitter to be dynamically dependent on the fit range.
- [x] Add for RGL only: the timeline of target window length: use upstream - downstream (original fit at (10,30))
- [x] Verified in p0v9 data

 Here is the updated selection manul:
<img width="822" height="526" alt="Screenshot 2026-04-08 at 12 05 37 PM" src="https://github.com/user-attachments/assets/7f65be1f-e83c-4c4b-8305-f878e27dd120" />

Now we have 3 different timeline:
downstream timeline (the default peak in all other run group)
<img width="1170" height="828" alt="Screenshot 2026-04-08 at 1 59 45 PM" src="https://github.com/user-attachments/assets/8372695f-b3a9-4e79-887a-7fd2c8f66772" />

upstream timeline
<img width="1176" height="823" alt="Screenshot 2026-04-08 at 1 59 31 PM" src="https://github.com/user-attachments/assets/33492b52-8609-406a-95d2-a267bbabb137" />


target window
<img width="1176" height="836" alt="Screenshot 2026-04-08 at 1 59 38 PM" src="https://github.com/user-attachments/assets/eed6c87b-e238-4e3b-a10a-6231d36251df" />

