### PR TITLE
Add the missing upstream fitting in the target window

### DIFF
--- a/src/main/java/org/jlab/clas/timeline/analysis/forward/forward_Tracking_EleVz.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/forward/forward_Tracking_EleVz.groovy
@@ -146,6 +146,12 @@ def write() {
 
       data_upstream.sort{it.key}.each{run,it->
         out.cd('/'+it.run)
+        def h = it.hlist[sec]    
+        def origName = h.getName() 
+        h.setName(origName+'_upstream')
+        out.addDataSet(h)
+        h.setName(origName) 
+        it.flist[sec].setName('fit:'+origName+'_upstream') 
         out.addDataSet(it.flist[sec])
         grtl_upstream.addPoint(it.run, it.mean[sec], 0, 0)
         def window_length = (data[run].mean[sec] - it.mean[sec]).abs()


### PR DESCRIPTION
This is a quick fix. In previous PR 462, the upstream fitting of target window was missing. I checked the code found it was overwritten by the downstream fit because they share same name. Now I simply change it as fit::sec?_upstream before saving. 
To present it also need a copy of the histogram. 

I tested it on p0v9 and it works:
(check out left, right bottom plot)
<img width="1160" height="828" alt="Screenshot 2026-04-08 at 5 14 05 PM" src="https://github.com/user-attachments/assets/025ae663-1d04-40e4-b651-ce5ec8743582" />
