### PR TITLE
doc(qadb): add `reheat` to the checklist, and set logger level for clock analysis

### DIFF
--- a/doc/qa.md
+++ b/doc/qa.md
@@ -71,6 +71,16 @@ If you are performing a manual QA as part of a cross check, skip to the next sec
 </details>
 
 <details>
+<summary>- [ ] reheat the data, if necessary</summary>
+
+- see [RG-A Spring 2018](/qadb/notes/rga_sp18.md) and [RG-K Fall 2018](/qadb/notes/rgk_fa18.md) for details
+- basically:
+  - use `qtl xcharge` to check the charge
+  - if reheating is needed, use `qtl reheat`
+  - use `qtl xcharge` afterward to check the reheated charge
+</details>
+
+<details>
 <summary>- [ ] verify run-dependent settings are correct for these data</summary>
 
 - the script [`monitorRead.groovy`](/qa-physics/monitorRead.groovy) contains some run-dependent settings

--- a/qa-physics/charge_analysis/analyze_clock.groovy
+++ b/qa-physics/charge_analysis/analyze_clock.groovy
@@ -7,6 +7,8 @@ import org.jlab.jnp.hipo4.data.Bank;
 import org.jlab.jnp.hipo4.data.SchemaFactory;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.logging.Logger;
+import java.util.logging.Level;
 
 if(args.length<4) {
   System.err.println """
@@ -22,6 +24,7 @@ def rollover = args[3] == '1'
 List<String> filenames = new ArrayList<>();
 filenames.add(in_file);
 
+Logger.getLogger("org.jlab.detector.scalers.DaqScalersSequence").setLevel(Level.INFO);
 ConstantsManager consts = new ConstantsManager();
 consts.init("/runcontrol/fcup","/runcontrol/slm","/runcontrol/helicity","/daq/config/scalers/dsc1","/runcontrol/hwp");
 DaqScalersSequence seq = DaqScalersSequence.rebuildSequence(1, consts, filenames);


### PR DESCRIPTION
- add reheat procedure to the QADB production checklist
- make sure the logger level for clock analysis is set correctly, so we can see the rollover-correction messages and warnings