### PR TITLE
Feat: add mean and width timelines of AHDC residual and residual_LR per wire per layer

### DIFF
--- a/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_ahdc_adc.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_ahdc_adc.groovy
@@ -75,7 +75,7 @@ int number_of_wires_per_timeline;
             def name = String.format('ahdc_adc_layer%d_wire_number%02d', layer_number, wire_number)
             def gr = new GraphErrors(name)
             gr.setTitle(  String.format("AHDC ADC %s layer %d", variable.replace('_', ' '), layer_number))
-            gr.setTitleY( String.format("AHDC ADC %s layer %d", variable.replace('_', ' '), layer_number))
+            gr.setTitleY( String.format("AHDC ADC %s", variable.replace('_', ' ')))
             gr.setTitleX("run number")
             data.sort{it.key}.each{run,it->
               out.mkdir('/'+it.run)

--- a/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_ahdc_residual.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_ahdc_residual.groovy
@@ -72,7 +72,7 @@ int number_of_wires_per_timeline;
             def name = String.format('ahdc_residual_layer%d_wire_number%02d', layer_number, wire_number)
             def gr = new GraphErrors(name)
             gr.setTitle(  String.format("AHDC Residual %s Layer %d", variable.replace('_', ' '), layer_number))
-            gr.setTitleY( String.format("AHDC Residual %s Layer %d", variable.replace('_', ' '), layer_number))
+            gr.setTitleY( String.format("AHDC Residual %s Layer %d (mm)", variable.replace('_', ' '), layer_number))
             gr.setTitleX("run number")
             data.sort{it.key}.each{run,it->
               out.mkdir('/'+it.run)

--- a/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_ahdc_residual.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_ahdc_residual.groovy
@@ -72,7 +72,7 @@ int number_of_wires_per_timeline;
             def name = String.format('ahdc_residual_layer%d_wire_number%02d', layer_number, wire_number)
             def gr = new GraphErrors(name)
             gr.setTitle(  String.format("AHDC Residual %s Layer %d", variable.replace('_', ' '), layer_number))
-            gr.setTitleY( String.format("AHDC Residual %s Layer %d (mm)", variable.replace('_', ' '), layer_number))
+            gr.setTitleY( String.format("AHDC Residual %s (mm)", variable.replace('_', ' ')))
             gr.setTitleX("run number")
             data.sort{it.key}.each{run,it->
               out.mkdir('/'+it.run)

--- a/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_ahdc_residual_LR.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_ahdc_residual_LR.groovy
@@ -71,8 +71,8 @@ int number_of_wires_per_timeline;
           if (wire_number <= number_of_wires_this_layer){
             def name = String.format('ahdc_residual_LR_layer%d_wire_number%02d', layer_number, wire_number)
             def gr = new GraphErrors(name)
-            gr.setTitle(  String.format("AHDC Residual LR %s Layer %d", variable.replace('_', ' '), layer_number))
-            gr.setTitleY( String.format("AHDC Residual LR %s Layer %d", variable.replace('_', ' '), layer_number))
+            gr.setTitle(  String.format("AHDC Residual LR %s Layer %d Wire %d", variable.replace('_', ' '), layer_number, wire_number))
+            gr.setTitleY( String.format("AHDC Residual LR %s (mm)", variable.replace('_', ' '), layer_number))
             gr.setTitleX("run number")
             data.sort{it.key}.each{run,it->
               out.mkdir('/'+it.run)

--- a/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_ahdc_residual_LR.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_ahdc_residual_LR.groovy
@@ -5,7 +5,7 @@ import org.jlab.groot.data.TDirectory
 import org.jlab.groot.data.GraphErrors
 import org.jlab.clas.timeline.fitter.ALERTFitter
 
-class alert_ahdc_residual {
+class alert_ahdc_residual_LR {
 
 def data = new ConcurrentHashMap()
 def has_data = new AtomicBoolean(false)
@@ -17,7 +17,7 @@ int layer;
 int number_of_wires_this_layer;
 int number_of_wires_per_timeline;
 
-  alert_ahdc_residual(int ahdc_layer_number) {
+  alert_ahdc_residual_LR(int ahdc_layer_number) {
       this.layer_number                 = ahdc_layer_number
       this.layer                        = layer_encoding[layer_number - 1];
       this.number_of_wires_this_layer   = layer_wires[layer_number - 1]
@@ -37,14 +37,14 @@ int number_of_wires_per_timeline;
     // data[run].put('bits',  trigger)
     float integral = 0;
     (1..number_of_wires_this_layer).collect{wire_number->
-      def h1 = dir.getObject(String.format("/ALERT/AHDC_RESIDUAL_layer%d_wire_number%02d", layer_number, wire_number))
+      def h1 = dir.getObject(String.format("/ALERT/AHDC_RESIDUAL_LR_layer%d_wire_number%02d", layer_number, wire_number))
       if(h1!=null) {
         if (h1.getBinContent(h1.getMaximumBin()) > 30 && h1.getEntries()>300){
-          data[run].put(String.format('ahdc_residual_layer%d_wire_number%02d', layer_number, wire_number),  h1)
+          data[run].put(String.format('ahdc_residual_LR_layer%d_wire_number%02d', layer_number, wire_number),  h1)
           def f1 = ALERTFitter.residual_fitter(h1)
-          data[run].put(String.format("fit_ahdc_residual_layer%d_wire_number%02d", layer_number, wire_number),  f1)
-          data[run].put(String.format("mean_ahdc_residual_layer%d_wire_number%02d", layer_number, wire_number),  f1.getParameter(1))
-          data[run].put(String.format("width_ahdc_residual_layer%d_wire_number%02d", layer_number, wire_number),  f1.getParameter(2).abs())
+          data[run].put(String.format("fit_ahdc_residual_LR_layer%d_wire_number%02d", layer_number, wire_number),  f1)
+          data[run].put(String.format("mean_ahdc_residual_LR_layer%d_wire_number%02d", layer_number, wire_number),  f1.getParameter(1))
+          data[run].put(String.format("width_ahdc_residual_LR_layer%d_wire_number%02d", layer_number, wire_number),  f1.getParameter(2).abs())
           has_data.set(true)
         }
       }
@@ -69,10 +69,10 @@ int number_of_wires_per_timeline;
         (1..number_of_wires_this_timeline).collect{wire_index->
           def wire_number = wire_index + 15* timeline_index
           if (wire_number <= number_of_wires_this_layer){
-            def name = String.format('ahdc_residual_layer%d_wire_number%02d', layer_number, wire_number)
+            def name = String.format('ahdc_residual_LR_layer%d_wire_number%02d', layer_number, wire_number)
             def gr = new GraphErrors(name)
-            gr.setTitle(  String.format("AHDC Residual %s Layer %d", variable.replace('_', ' '), layer_number))
-            gr.setTitleY( String.format("AHDC Residual %s Layer %d", variable.replace('_', ' '), layer_number))
+            gr.setTitle(  String.format("AHDC Residual LR %s Layer %d", variable.replace('_', ' '), layer_number))
+            gr.setTitleY( String.format("AHDC Residual LR %s Layer %d", variable.replace('_', ' '), layer_number))
             gr.setTitleX("run number")
             data.sort{it.key}.each{run,it->
               out.mkdir('/'+it.run)
@@ -88,7 +88,7 @@ int number_of_wires_per_timeline;
             out.addDataSet(gr)
           }
         }
-        out.writeFile(String.format('alert_ahdc_residual_%s_layer%d_%d.hipo', variable, layer_number, timeline_index))
+        out.writeFile(String.format('alert_ahdc_residual_LR_%s_layer%d_%d.hipo', variable, layer_number, timeline_index))
       }
     }
   }

--- a/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_ahdc_time.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_ahdc_time.groovy
@@ -88,7 +88,7 @@ int number_of_wires_per_timeline;
             def name = String.format('ahdc_time_layer%d_wire_number%02d', layer_number, wire_number)
             def gr = new GraphErrors(name)
             gr.setTitle(  String.format("AHDC Time %s Layer %d", variable.replace('_', ' '), layer_number))
-            gr.setTitleY( String.format("AHDC Time %s Layer %d", variable.replace('_', ' '), layer_number))
+            gr.setTitleY( String.format("AHDC Time %s (ns)", variable.replace('_', ' ')))
             gr.setTitleX("run number")
             data.sort{it.key}.each{run,it->
               out.mkdir('/'+it.run)

--- a/src/main/java/org/jlab/clas/timeline/fitter/ALERTFitter.groovy
+++ b/src/main/java/org/jlab/clas/timeline/fitter/ALERTFitter.groovy
@@ -216,10 +216,10 @@ class ALERTFitter{
 		f1.setOptStat("1111");
 		double maxz = h1.getBinContent(h1.getMaximumBin());
 		double peak_location = h1.getAxis().getBinCenter(h1.getMaximumBin());
-		f1.setRange(peak_location - 2.5, peak_location + 2.5);
+		f1.setRange(peak_location - 1.0, peak_location + 1.0);
 		f1.setParameter(0,maxz-h1.getBinContent(0));
 		f1.setParameter(1, peak_location);
-		f1.setParameter(2, 0.5);
+		f1.setParameter(2, 0.2);
 		f1.setParameter(3, h1.getBinContent(0));
 		if (maxz>0) f1.setParLimits(0, maxz*0.9,maxz*1.1);
 		f1.setParLimits(3, 0.0, 0.1*maxz);

--- a/src/main/java/org/jlab/clas/timeline/histograms/ALERT.java
+++ b/src/main/java/org/jlab/clas/timeline/histograms/ALERT.java
@@ -27,7 +27,7 @@ public class ALERT {
 
   //Hodoscope
   public H1F[] ATOF_Time, ATOF_Time_sl, ATOF_z, ATOF_z_sl, ATOF_z_c4, ATOF_z_c4_sl;
-  public H1F[] ADC, AHDC_RESIDUAL, AHDC_TIME;//AHDC-related-histograms
+  public H1F[] ADC, AHDC_RESIDUAL, AHDC_RESIDUAL_LR, AHDC_TIME;//AHDC-related-histograms
   private H1F bits;
 
   public IndexedTable rfTable;
@@ -106,7 +106,8 @@ public class ALERT {
 
     //AHDC ADC Histograms
     ADC           = new H1F[576];
-    AHDC_RESIDUAL = new H1F[8];
+    AHDC_RESIDUAL = new H1F[576];
+    AHDC_RESIDUAL_LR = new H1F[576];
     AHDC_TIME     = new H1F[576];
 
     for (int index = 0; index<576; index++) {
@@ -128,14 +129,14 @@ public class ALERT {
       AHDC_TIME[index].setTitleX("AHDC TIME (ns)");
       AHDC_TIME[index].setTitleY("Counts");
       AHDC_TIME[index].setFillColor(4);
-    }
-
-    for (int k=0; k<8; k++){
-
-      AHDC_RESIDUAL[k] = new H1F(String.format("AHDC_RESIDUAL_layer%d", layer_encoding[k]), String.format("AHDC Residual layer%d", layer_encoding[k]), 300, -20.0f, 10.0f);
-      AHDC_RESIDUAL[k].setTitleX("AHDC RESIDUAL (mm)");
-      AHDC_RESIDUAL[k].setTitleY("Counts");
-      AHDC_RESIDUAL[k].setFillColor(4);
+      AHDC_RESIDUAL[index] = new H1F(String.format("AHDC_RESIDUAL_layer%d_wire_number%02d", layer_number, wire_number), String.format("AHDC Residual layer%d wire number%02d", layer_number, wire_number), 200, -7.0f, 3.0f);
+      AHDC_RESIDUAL[index].setTitleX("AHDC RESIDUAL (mm)");
+      AHDC_RESIDUAL[index].setTitleY("Counts");
+      AHDC_RESIDUAL[index].setFillColor(4);
+      AHDC_RESIDUAL_LR[index] = new H1F(String.format("AHDC_RESIDUAL_LR_layer%d_wire_number%02d", layer_number, wire_number), String.format("AHDC Residual SL layer%d wire number%02d", layer_number, wire_number), 200, -5.0f, 5.0f);
+      AHDC_RESIDUAL_LR[index].setTitleX("AHDC RESIDUAL LR (mm)");
+      AHDC_RESIDUAL_LR[index].setTitleY("Counts");
+      AHDC_RESIDUAL_LR[index].setFillColor(4);
     }
 
     // Trigger bits
@@ -170,13 +171,15 @@ public class ALERT {
       int component   = ahdc_hits.getInt("wire", loop);
       float time      = (float) ahdc_hits.getDouble("time", loop);
       float residual  = (float) ahdc_hits.getDouble("residual", loop);
+      float residual_LR  = (float) ahdc_hits.getDouble("residual_LR", loop);
       int index = 0;
 
       layer = superlayer * 10 + layer;
       int layer_number = Arrays.asList(boxed_encoding).indexOf(layer) + 1;
       index = component - 1 + layer_wires_cumulative[layer_number - 1];
 
-      if (Math.signum(residual) != 0) AHDC_RESIDUAL[layer_number - 1].fill(residual);
+      if (Math.signum(residual) != 0) AHDC_RESIDUAL[index].fill(residual);
+      if (Math.signum(residual_LR) != 0) AHDC_RESIDUAL_LR[index].fill(residual_LR);
       AHDC_TIME[index].fill(time);
     }
   }
@@ -297,10 +300,7 @@ public class ALERT {
       dirout.addDataSet(ATOF_Time_sl[gcomponent]);
     }
     for (int index = 0; index < 576; index++) {
-      dirout.addDataSet(ADC[index], AHDC_TIME[index]);
-    }
-    for (int index = 0; index < 8; index++){
-      dirout.addDataSet(AHDC_RESIDUAL[index]);
+      dirout.addDataSet(ADC[index], AHDC_TIME[index], AHDC_RESIDUAL[index], AHDC_RESIDUAL_LR[index]);
     }
 
     dirout.mkdir("/TRIGGER/");

--- a/src/main/java/org/jlab/clas/timeline/run_analysis.groovy
+++ b/src/main/java/org/jlab/clas/timeline/run_analysis.groovy
@@ -7,7 +7,8 @@ import org.jlab.groot.data.TDirectory
 def engines = [
   out_ALERT: [
     *(1..8).collect {ahdc_layer_number -> new alert_ahdc_adc (ahdc_layer_number) },
-    new alert_ahdc_residual(),
+    *(1..8).collect {ahdc_layer_number -> new alert_ahdc_residual (ahdc_layer_number) },
+    *(1..8).collect {ahdc_layer_number -> new alert_ahdc_residual_LR (ahdc_layer_number) },
     *(1..8).collect {ahdc_layer_number -> new alert_ahdc_time (ahdc_layer_number) },
     new alert_atof_time(),
     *(0..<15).collectMany { s -> (0..<4).collect { l -> new alert_atof_time_sl(s, l) } },


### PR DESCRIPTION
This PR is linked to Issue #475 .

Tested with 30 randomly selected runs in Felix's directory
```
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00013.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00022.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00062.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00114.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00115.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00123.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00132.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00134.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00158.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00219.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00254.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00291.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00295.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00346.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00354.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00358.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00406.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00412.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00415.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00422.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00517.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00531.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00541.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00551.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00635.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00681.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00724.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00771.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00786.hipo
/volatile/clas12/touchte/sync-coat/reconstructed/022712/rec_clas_022712.evio.00793.hipo
```

The timeline looks good: https://clas12mon.jlab.org/rgl/ahdc_residual_test/alert/timeline/

I encourage AHDC experts to look at fitting quality and suggest edits for src/main/java/org/jlab/clas/timeline/fitter/ALERTFitter.groovy