### PR TITLE
fix!: missing tag-1 cut on helicity latched charge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,10 +193,10 @@ jobs:
             -p web \
             --custom-pub \
             ${{matrix.args}}
+      - run: tree outfiles
       - name: dump charge
         if: ${{ matrix.type == 'physics' }}
-        run: util/dump-charges.rb outfiles/${{env.dataset}}/outdat/chargeTree.json
-      - run: tree outfiles
+        run: util/dump-charges.rb outfiles/${{env.dataset}}/timeline_physics_qa/outdat/chargeTree.json
       - name: summarize
         run: |
           echo "# Output File Tree" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,9 @@ jobs:
             -p web \
             --custom-pub \
             ${{matrix.args}}
+      - name: dump charge
+        if: ${{ matrix.type == 'physics' }}
+        run: util/dump-charges.rb outfiles/${{env.dataset}}/outdat/chargeTree.json
       - run: tree outfiles
       - name: summarize
         run: |

--- a/qa-physics/monitorRead.groovy
+++ b/qa-physics/monitorRead.groovy
@@ -564,7 +564,7 @@ inHipoList.each { inHipoFile ->
   // EVENT LOOP
   while(reader.hasEvent()) {
     hipoEvent = reader.getNextEvent()
-    def tag = ((HipoDataEvent) event).getHipoEvent().getEventTag()
+    def tag = ((HipoDataEvent) hipoEvent).getHipoEvent().getEventTag()
 
     // get required banks
     particleBank   = hipoEvent.getBank("REC::Particle")

--- a/qa-physics/monitorRead.groovy
+++ b/qa-physics/monitorRead.groovy
@@ -4,6 +4,8 @@
 // - note: search for 'CUT' to find which cuts are applied
 
 import org.jlab.io.hipo.HipoDataSource
+import org.jlab.io.hipo.HipoDataEvent
+import org.jlab.jnp.hipo4.data.Event
 import org.jlab.clas.physics.Particle
 import org.jlab.groot.data.H1F
 import org.jlab.groot.data.H2F
@@ -562,6 +564,7 @@ inHipoList.each { inHipoFile ->
   // EVENT LOOP
   while(reader.hasEvent()) {
     hipoEvent = reader.getNextEvent()
+    def tag = ((HipoDataEvent) event).getHipoEvent().getEventTag()
 
     // get required banks
     particleBank   = hipoEvent.getBank("REC::Particle")
@@ -630,7 +633,7 @@ inHipoList.each { inHipoFile ->
     }
     // get scaler helicity from `HEL::scaler`, and fill its charge-weighted distribution
     // NOTE: do not do this if FCmode==CUSTOM (since FC charge is wrong)
-    if(hipoEvent.hasBank("HEL::scaler") && FCmode!=FCmodeEnum.CUSTOM) {
+    if(tag==1 && hipoEvent.hasBank("HEL::scaler") && FCmode!=FCmodeEnum.CUSTOM) {
       helScalerBank.rows().times{ row -> // HEL::scaler readouts "pile up", so there are multiple bank rows in an event
         def sc_helicity = helScalerBank.getByte("helicity", row)
         def sc_fc       = helScalerBank.getFloat("fcupgated", row) // helicity-latched FC charge

--- a/util/dump-charges.rb
+++ b/util/dump-charges.rb
@@ -1,0 +1,57 @@
+#!/usr/bin/env ruby
+
+# dump total charges for a given 'chargeTree.json' file
+
+require 'json'
+
+# args
+unless ARGV.length == 1
+  $stderr.puts "USAGE #{$0} [chargeTree.json file]"
+  exit 2
+end
+chargeTree = JSON.parse(File.read(ARGV[0]))
+
+# charge value names (and run number); these'll be the columns to be printed
+q_keys = [
+  'runnum',
+  'dsc2_qg',
+  'dsc2_qu',
+  'struck_helP_qg',
+  'struck_hel0_qg',
+  'struck_helN_qg',
+  'struck_totl_qg',
+]
+
+# print a row
+def row(cols)
+  puts cols.map{ |c| c.to_s.ljust 15}.join(' ')
+end
+
+# print the header row
+row q_keys
+
+# loop over run numbers
+chargeTree.each do |runnum, bins|
+
+  # compute the total charge by summing over the bins' charge
+  q = q_keys.map{ |k| [k, 0.0] }.to_h
+  bins.each_value do |b|
+    q['dsc2_qg']        += b['fcChargeMax']  - b['fcChargeMin']
+    q['dsc2_qu']        += b['ufcChargeMax'] - b['ufcChargeMin']
+    q['struck_helP_qg'] += b['fcChargeHelicity']['1']
+    q['struck_hel0_qg'] += b['fcChargeHelicity']['0']
+    q['struck_helN_qg'] += b['fcChargeHelicity']['-1']
+  end
+  q['struck_totl_qg'] = q['struck_helP_qg'] + q['struck_hel0_qg'] + q['struck_helN_qg']
+  q['runnum'] = runnum
+
+  # round them to a few decimal places
+  q_keys.each do |key|
+    next if key=='runnum'
+    q[key] = q[key].round 2
+  end
+
+  # print them
+  row q.values
+
+end


### PR DESCRIPTION
The helicity-latched charge is overestimated in the QADB, since we were missing the tag-1 cut. All QADBs with helicity-latched charge must be reproduced.

I cross checked runs `5249,5414,5520,5645,6616,6618` from RG-A Fall18 and Spring19, and all of them produce STRUCK charge values that agree from DSTs, nSidis files, and DVCSWagon files. Their DSC2 values also agree with those from the QADB (since those are not impacted by this issue).

The values also agree with those produced by the work-in-progress #470.