### PR TITLE
fix: use `RUN::config` by default for run number in `qtl histogram`

### DIFF
--- a/bin/qtl-histogram
+++ b/bin/qtl-histogram
@@ -17,7 +17,7 @@ SLURM_LOG=/farm_out/%u/%x-%A_%a
 # default options
 dataset=test_v0
 declare -A modes
-for key in dstdir skimdir findhipo eachdir rundir flatdir single series submit check-cache check-charge fast-ls swifjob focus-detectors focus-physics focus-qadb help; do
+for key in dstdir skimdir findhipo eachdir rundir flatdir single series submit check-cache check-charge fast-ls fast-runnum swifjob focus-detectors focus-physics focus-qadb help; do
   modes[$key]=false
 done
 outputDir=""
@@ -141,6 +141,11 @@ usageVerbose() {
                            - WARNING: assumes you already tested \`--check-cache\`,
                                       since \`jasmine\` uses \`/mss\` stub files
                            - useful for options such as \`--dstdir\` for DST files
+
+       --fast-runnum       attempt to use the file or directory name to get the run number,
+                           rather than opening a HIPO file and looking at \`RUN::config\`;
+                           - this is faster, but less reliable (may get the wrong number)
+                           - if it gets no number, it will fallback to using \`RUN::config\`
 
   $sep
 
@@ -333,18 +338,23 @@ done
 echo "Determining run number list..."
 declare -A runnumHash # `rdirs` element -> run number
 for rdir in ${rdirs[@]}; do
-  # get the run number, either from `rdir` basename (fast), or from `RUN::config` (slow)
   [[ ! -e $rdir ]] && printError "the run file/directory '$rdir' does not exist" && continue
-  runnum=$(basename $rdir | grep -m1 -o -E "[0-9]+" | tail -n1 || echo '') # first, try from run directory (or file) basename
-  if [ -z "$runnum" ] || ${modes['swifjob']}; then # otherwise, use RUN::config from a HIPO file (NOTE: assumes all HIPO files have the same run number)
+  runnum=''
+  # fast method: parse the `rdir` basename
+  if ${modes['fast-runnum']}; then
+    echo "... using \`--fast-runnum\` to get run number from '$rdir'"
+    runnum=$(basename $rdir | grep -m1 -o -E "[0-9]+" | tail -n1 || echo '')
+  fi
+  # slow method: open a HIPO file and check `RUN::config`
+  if [ -z "$runnum" ] || ${modes['swifjob']}; then
+    echo "... using \`RUN::config\` to get run number from; use \`--fast-runnum\` if this is too slow ..."
     if ${modes['skimdir']}; then
-      $TIMELINESRC/libexec/hipo-check.sh $rdir
+      # $TIMELINESRC/libexec/hipo-check.sh $rdir # this is slow, but run number retrieval will likely fail if the file is bad
       runnum=$($TIMELINESRC/libexec/run-groovy-timeline.sh $TIMELINESRC/libexec/get-run-number.groovy $rdir | tail -n1 | grep -m1 -o -E "[0-9]+" || echo '')
     else
-      firstHipo=$(find $rdir -name "*.hipo" | head -n1)
+      firstHipo=$(find $rdir -name "*.hipo" | head -n1) # NOTE: assumes all HIPO files have the same run number
       [ -z "$firstHipo" ] && printError "no HIPO files in run directory '$rdir'; cannot get run number or create job" && continue
-      echo "using HIPO file $firstHipo to get run number for run directory '$rdir'"
-      $TIMELINESRC/libexec/hipo-check.sh $firstHipo
+      # $TIMELINESRC/libexec/hipo-check.sh $firstHipo # this is slow, but run number retrieval will likely fail if the file is bad
       runnum=$($TIMELINESRC/libexec/run-groovy-timeline.sh $TIMELINESRC/libexec/get-run-number.groovy $firstHipo | tail -n1 | grep -m1 -o -E "[0-9]+" || echo '')
     fi
   fi
@@ -356,6 +366,7 @@ done
 echo "RUN NUMBERS = {"
 for rdir in "${!runnumHash[@]}"; do echo "  $rdir => ${runnumHash[$rdir]},"; done
 echo "}"
+[ -z "${runnumHash[@]+x}" ] && printError "list of run numbers is empty" && exit 100
 echo $sep
 
 # get beam energy for each run number


### PR DESCRIPTION
I finally hit a case where the filename parsing returns the _wrong_ number. So,

- switch to using `RUN::config` by default, which is a bit slower
- remove the `hipo-check` pre-check, since that's much much slower, and looking at `RUN::config` will probably fail anyway if the file is bad
- add option `--fast-runnum` for impatient users who trust the file name parsing