### PR TITLE
fix: remove warning recommending to contact Chris

### DIFF
--- a/src/main/java/org/jlab/clas/timeline/run_histograms.java
+++ b/src/main/java/org/jlab/clas/timeline/run_histograms.java
@@ -103,7 +103,6 @@ public class run_histograms {
       }
       catch (RuntimeException e) {
         System.err.println("WARNING: Failed to construct QadbBinSequence; reason: " + e.getMessage());
-        System.err.println("         If you're a chef, just notify Chris Dilks; this won't impact calibration timelines");
       }
     }
     if(enableHistosDet) {


### PR DESCRIPTION
I got an opportunity to test the new QADB timeline code with a chef's workflow with the help of @mathieuouillon. It works, for the most part, so I don't think chefs need to be told to contact me. I'll be watching these new timelines anyway.