### PR TITLE
fix: `find` writes to closed pipe and fails silently

### DIFF
--- a/bin/qtl-analysis
+++ b/bin/qtl-analysis
@@ -439,7 +439,13 @@ if $enableAna; then
   # remove any empty directories
   echo ">>> removing any empty directories..."
   for detDir in ${detDirs[@]}; do
-    [ -z "$(find $detDir -name '*.hipo')" ] && rm -rv $detDir
+    foundFiles=$(find $detDir -name '*.hipo')
+    findStatus=$?
+    if [ $findStatus -ne 0 ]; then
+      printWarning "\`find\` failed on $detDir, skipping removal"
+    elif [ -z "$foundFiles" ]; then
+      rm -rv $detDir
+    fi
   done
 
   echo ">>> done producing timelines..."

--- a/bin/qtl-histogram
+++ b/bin/qtl-histogram
@@ -347,12 +347,13 @@ for rdir in ${rdirs[@]}; do
   fi
   # slow method: open a HIPO file and check `RUN::config`
   if [ -z "$runnum" ] || ${modes['swifjob']}; then
-    echo "... using \`RUN::config\` to get run number from; use \`--fast-runnum\` if this is too slow ..."
+    echo "... using \`RUN::config\` to get run number from '$rdir'; use \`--fast-runnum\` if this is too slow ..."
     if ${modes['skimdir']}; then
       # $TIMELINESRC/libexec/hipo-check.sh $rdir # this is slow, but run number retrieval will likely fail if the file is bad
       runnum=$($TIMELINESRC/libexec/run-groovy-timeline.sh $TIMELINESRC/libexec/get-run-number.groovy $rdir | tail -n1 | grep -m1 -o -E "[0-9]+" || echo '')
     else
-      firstHipo=$(find $rdir -name "*.hipo" | head -n1) # NOTE: assumes all HIPO files have the same run number
+      firstHipo=$(find $rdir -name "*.hipo" -print -quit) # NOTE: assumes all HIPO files have the same run number
+      echo "    ... from a HIPO file within, '$firstHipo'"
       [ -z "$firstHipo" ] && printError "no HIPO files in run directory '$rdir'; cannot get run number or create job" && continue
       # $TIMELINESRC/libexec/hipo-check.sh $firstHipo # this is slow, but run number retrieval will likely fail if the file is bad
       runnum=$($TIMELINESRC/libexec/run-groovy-timeline.sh $TIMELINESRC/libexec/get-run-number.groovy $firstHipo | tail -n1 | grep -m1 -o -E "[0-9]+" || echo '')
@@ -362,6 +363,7 @@ for rdir in ${rdirs[@]}; do
   [ $runnum -eq 0 ] && printError "unknown run number for '$rdir'; ignoring it!" && continue
   runnum=$((10#$runnum))
   runnumHash[$rdir]=$runnum
+  echo "    -> run number = $runnum"
 done
 echo "RUN NUMBERS = {"
 for rdir in "${!runnumHash[@]}"; do echo "  $rdir => ${runnumHash[$rdir]},"; done

--- a/qa-physics/stageTimelines.sh
+++ b/qa-physics/stageTimelines.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # copy timeline hipo files to output timelines area, staging them for deployment
 
-set -e
+set -euo pipefail
 
 if [ $# -ne 2 ]; then
   echo "USAGE: $0 [input_dir] [output_dir]" >&2
@@ -15,7 +15,14 @@ inputDir=$1/outmon
 outputDir=$2
 
 # check HIPO files
+set +o pipefail
 timelineFiles=$(find $inputDir -name "*.hipo" -type f | grep -v 'monitorElec')
+findStatus=${PIPESTATUS[0]}
+set -o pipefail
+if (( findStatus != 0 )); then
+  echo "ERROR: \`find\` failed in $inputDir" >&2
+  exit 1
+fi
 $TIMELINESRC/libexec/hipo-check.sh $timelineFiles
 
 # copy timelines to output directory


### PR DESCRIPTION
In the context of `set -e` and `set -o pipefail`, the pattern
```bash
find ... | head -n1
```
will silently fail, and may not even return a non-zero exit code. This is because `head -n1` can close the pipe _before_ the `find` command is done executing. The same thing happens with the `find | grep` pattern.

I specifically hit this when running
```bash
bin/qtl histogram -d rgk_fa23_6.4GeV --check-charge --dstdir --focus-physics /cache/clas12/rg-k/production/recon/fall2023/pass1/6395MeV/dst/recon/
```
in particular, `--dstdir` causes such a `find | head n1` to be called; the script terminates immediately and exits 0 (success) with no errors printed.

This PR addresses this specific one, and a few others from `find` pipes. Note there may be other similar such pipe issues around, but this PR targets just `find` since we use that a lot here (in place of `ls`)
- `find | head -n1` can easily be replaced by `find -quit` (does the same thing, but successfully)
- other cases require temporarily disabling `pipefail` and inspecting the pipe status before proceeding
