### PR TITLE
(alert): improve ATOF bar_z c4 histogram binning and fitting

### DIFF
--- a/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_atof_z_c4.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_atof_z_c4.groovy
@@ -14,7 +14,7 @@ class alert_atof_z_c4 {
     data[run] = [run:run]
     def h1 = dir.getObject('/ALERT/ATOF_z_combined_c4')
     if (h1 != null) {
-      if (h1.getBinContent(h1.getMaximumBin()) > 3 && h1.getEntries() > 10) {
+      if (h1.getBinContent(h1.getMaximumBin()) > 3 && h1.getEntries() > 50) {
         data[run].put('atof_z_c4_combined', h1)
         def f1 = ALERTFitter.atof_z_fitter(h1)
         data[run].put('fit_atof_z_c4_combined', f1)

--- a/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_atof_z_c4.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_atof_z_c4.groovy
@@ -15,8 +15,8 @@ class alert_atof_z_c4 {
     def h1 = dir.getObject('/ALERT/ATOF_z_combined_c4')
     if (h1 != null) {
       if (h1.getBinContent(h1.getMaximumBin()) > 3 && h1.getEntries() > 50) {
-        data[run].put('atof_z_c4_combined', h1)
-        def f1 = ALERTFitter.atof_z_fitter(h1)
+        def (h1r, f1) = ALERTFitter.atof_z_fitter(h1)
+        data[run].put('atof_z_c4_combined', h1r)
         data[run].put('fit_atof_z_c4_combined', f1)
         data[run].put('peak_location_atof_z_c4_combined', f1.getParameter(1))
         data[run].put('sigma_atof_z_c4_combined', f1.getParameter(2).abs())

--- a/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_atof_z_c4_sl.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_atof_z_c4_sl.groovy
@@ -27,8 +27,8 @@ class alert_atof_z_c4_sl {
     if (h1 != null) {
       if (h1.getBinContent(h1.getMaximumBin()) > 3 && h1.getEntries() > 50) {
         def name = String.format('atof_z_c4_sl_s%02d_l%d', sector, layer)
-        data[run].put(name, h1)
-        def f1 = ALERTFitter.atof_z_fitter(h1)
+        def (h1r, f1) = ALERTFitter.atof_z_fitter(h1)
+        data[run].put(name, h1r)
         data[run].put('fit_' + name, f1)
         data[run].put('peak_location_' + name, f1.getParameter(1))
         data[run].put('sigma_' + name, f1.getParameter(2).abs())

--- a/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_atof_z_c4_sl.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/alert/alert_atof_z_c4_sl.groovy
@@ -25,7 +25,7 @@ class alert_atof_z_c4_sl {
     data[run] = [run:run]
     def h1 = dir.getObject(String.format('/ALERT/ATOF_z_c4_sector%02d_layer%02d', sector, layer))
     if (h1 != null) {
-      if (h1.getBinContent(h1.getMaximumBin()) > 3 && h1.getEntries() > 10) {
+      if (h1.getBinContent(h1.getMaximumBin()) > 3 && h1.getEntries() > 50) {
         def name = String.format('atof_z_c4_sl_s%02d_l%d', sector, layer)
         data[run].put(name, h1)
         def f1 = ALERTFitter.atof_z_fitter(h1)

--- a/src/main/java/org/jlab/clas/timeline/fitter/ALERTFitter.groovy
+++ b/src/main/java/org/jlab/clas/timeline/fitter/ALERTFitter.groovy
@@ -292,7 +292,7 @@ class ALERTFitter{
 
         double maxz = h1.getBinContent(h1.getMaximumBin())
         double peak = h1.getAxis().getBinCenter(h1.getMaximumBin())
-        double sigma = ALERTFitter.getRestrictedRMS(h1, peak-75, peak+75)
+//        double sigma = ALERTFitter.getRestrictedRMS(h1, peak-75, peak+75)
         def f1 = new F1D("fit:" + h1.getName(), "[amp]*gaus(x,[mean],[sigma])", peak - 75, peak + 75)
         f1.setLineColor(33)
         f1.setLineWidth(10)

--- a/src/main/java/org/jlab/clas/timeline/fitter/ALERTFitter.groovy
+++ b/src/main/java/org/jlab/clas/timeline/fitter/ALERTFitter.groovy
@@ -269,24 +269,29 @@ class ALERTFitter{
     }
 
 
-    static F1D atof_z_fitter(H1F h1){
-        // Rebin a clone for fitting if low statistics; original h1 is not modified
-        H1F hfit = h1
-        int entries = (int) h1.getEntries()
-        if (entries < 400) {
-            int ngroup = (entries < 200) ? 4 : 2
-            int nbins = h1.getAxis().getNBins()
-            int newbins = nbins / ngroup
-            hfit = new H1F("hfit_rebin", newbins, h1.getAxis().min(), h1.getAxis().max())
-            for (int i = 0; i < newbins; i++) {
-                float sum = 0
-                for (int j = 0; j < ngroup; j++) sum += h1.getBinContent(i * ngroup + j)
-                hfit.setBinContent(i, sum)
-            }
+    static H1F rebinH1F(H1F h, int ngroup) {
+        int nbins = h.getAxis().getNBins()
+        int newbins = nbins / ngroup
+        def hr = new H1F(h.getName(), h.getTitle(), newbins, h.getAxis().min(), h.getAxis().max())
+        for (int i = 0; i < newbins; i++) {
+            double sum = 0
+            for (int j = 0; j < ngroup; j++) sum += h.getBinContent(i * ngroup + j)
+            hr.setBinContent(i, sum)
         }
+        hr.setTitleX(h.getTitleX())
+        hr.setTitleY(h.getTitleY())
+        hr.setFillColor(h.getFillColor())
+        return hr
+    }
 
-        double maxz = hfit.getBinContent(hfit.getMaximumBin())
-        double peak = hfit.getAxis().getBinCenter(hfit.getMaximumBin())
+    static List atof_z_fitter(H1F h1){
+        // Rebin for low statistics
+        int entries = (int) h1.getEntries()
+        if (entries < 200)      h1 = rebinH1F(h1, 4)
+        else if (entries < 400) h1 = rebinH1F(h1, 2)
+
+        double maxz = h1.getBinContent(h1.getMaximumBin())
+        double peak = h1.getAxis().getBinCenter(h1.getMaximumBin())
 
         def f1 = new F1D("fit:" + h1.getName(), "[amp]*gaus(x,[mean],[sigma])", peak - 75, peak + 75)
         f1.setLineColor(33)
@@ -301,12 +306,10 @@ class ALERTFitter{
 
         PrintStream original = System.out
         System.setOut(new PrintStream(OutputStream.nullOutputStream()))
-        DataFitter.fit(f1, hfit, "RQ")
+        DataFitter.fit(f1, h1, "RQ")
         System.setOut(original)
 
-        if (entries < 400) hfit = null
-
-        return f1
+        return [h1, f1]
     }
 
     static F1D residual_fitter(H1F h1){

--- a/src/main/java/org/jlab/clas/timeline/fitter/ALERTFitter.groovy
+++ b/src/main/java/org/jlab/clas/timeline/fitter/ALERTFitter.groovy
@@ -292,14 +292,14 @@ class ALERTFitter{
 
         double maxz = h1.getBinContent(h1.getMaximumBin())
         double peak = h1.getAxis().getBinCenter(h1.getMaximumBin())
-
+        double sigma = ALERTFitter.getRestrictedRMS(h1, peak-75, peak+75)
         def f1 = new F1D("fit:" + h1.getName(), "[amp]*gaus(x,[mean],[sigma])", peak - 75, peak + 75)
         f1.setLineColor(33)
         f1.setLineWidth(10)
         f1.setOptStat("1111")
         f1.setParameter(0, maxz)
         f1.setParameter(1, peak)
-        f1.setParameter(2, 15.0)
+        f1.setParameter(2, sigma)
         if (maxz > 0) f1.setParLimits(0, maxz * 0.5, maxz * 1.5)
         f1.setParLimits(1, peak - 50.0, peak + 50.0)
         f1.setParLimits(2, 0.01, 100.0)

--- a/src/main/java/org/jlab/clas/timeline/fitter/ALERTFitter.groovy
+++ b/src/main/java/org/jlab/clas/timeline/fitter/ALERTFitter.groovy
@@ -288,7 +288,7 @@ class ALERTFitter{
         double maxz = hfit.getBinContent(hfit.getMaximumBin())
         double peak = hfit.getAxis().getBinCenter(hfit.getMaximumBin())
 
-        def f1 = new F1D("fit:" + h1.getName(), "[amp]*gaus(x,[mean],[sigma])", peak - 100, peak + 100)
+        def f1 = new F1D("fit:" + h1.getName(), "[amp]*gaus(x,[mean],[sigma])", peak - 75, peak + 75)
         f1.setLineColor(33)
         f1.setLineWidth(10)
         f1.setOptStat("1111")

--- a/src/main/java/org/jlab/clas/timeline/fitter/ALERTFitter.groovy
+++ b/src/main/java/org/jlab/clas/timeline/fitter/ALERTFitter.groovy
@@ -299,16 +299,17 @@ class ALERTFitter{
         f1.setOptStat("1111")
         f1.setParameter(0, maxz)
         f1.setParameter(1, peak)
-        f1.setParameter(2, sigma)
+        f1.setParameter(2, 15)
         if (maxz > 0) f1.setParLimits(0, maxz * 0.5, maxz * 1.5)
         f1.setParLimits(1, peak - 50.0, peak + 50.0)
-        f1.setParLimits(2, 0.01, 100.0)
+        f1.setParLimits(2, 0.01, 200.0)
 
-        PrintStream original = System.out
-        System.setOut(new PrintStream(OutputStream.nullOutputStream()))
-        DataFitter.fit(f1, h1, "RQ")
-        System.setOut(original)
+//        PrintStream original = System.out
+//        System.setOut(new PrintStream(OutputStream.nullOutputStream()))
+//        DataFitter.fit(f1, h1, "RQ")
+//        System.setOut(original)
 
+        DataFitter.fit(f1, h1, "")
         return [h1, f1]
     }
 

--- a/src/main/java/org/jlab/clas/timeline/fitter/ALERTFitter.groovy
+++ b/src/main/java/org/jlab/clas/timeline/fitter/ALERTFitter.groovy
@@ -310,6 +310,15 @@ class ALERTFitter{
 //        System.setOut(original)
 
         DataFitter.fit(f1, h1, "")
+
+        double fitted_mean  = f1.getParameter(1)
+        double fitted_sigma = f1.getParameter(2)
+        println(String.format("[atof_z_fit] %s: mean=%.1f sigma=%.1f (init: peak=%.1f sigma=15)",
+            h1.getName(), fitted_mean, fitted_sigma, peak))
+        if (Math.abs(fitted_sigma - 15.0) < 0.1) {
+            println(String.format("[atof_z_fit] WARNING: %s sigma unchanged from default — fit likely failed", h1.getName()))
+        }
+
         return [h1, f1]
     }
 

--- a/src/main/java/org/jlab/clas/timeline/fitter/ALERTFitter.groovy
+++ b/src/main/java/org/jlab/clas/timeline/fitter/ALERTFitter.groovy
@@ -313,10 +313,32 @@ class ALERTFitter{
 
         double fitted_mean  = f1.getParameter(1)
         double fitted_sigma = f1.getParameter(2)
-        println(String.format("[atof_z_fit] %s: mean=%.1f sigma=%.1f (init: peak=%.1f sigma=15)",
-            h1.getName(), fitted_mean, fitted_sigma, peak))
+        println(String.format("[atof_z_fit] %s: entries=%d nbins=%d maxbin=%.0f peak=%.1f -> mean=%.1f sigma=%.1f",
+            h1.getName(), entries, h1.getAxis().getNBins(), maxz, peak, fitted_mean, fitted_sigma))
+
         if (Math.abs(fitted_sigma - 15.0) < 0.1) {
-            println(String.format("[atof_z_fit] WARNING: %s sigma unchanged from default — fit likely failed", h1.getName()))
+            println(String.format("[atof_z_fit] %s: first fit failed, retrying with rebin x2", h1.getName()))
+            h1 = rebinH1F(h1, 2)
+            maxz = h1.getBinContent(h1.getMaximumBin())
+            peak = h1.getAxis().getBinCenter(h1.getMaximumBin())
+            f1 = new F1D("fit:" + h1.getName(), "[amp]*gaus(x,[mean],[sigma])", peak - 75, peak + 75)
+            f1.setLineColor(33)
+            f1.setLineWidth(10)
+            f1.setOptStat("1111")
+            f1.setParameter(0, maxz)
+            f1.setParameter(1, peak)
+            f1.setParameter(2, 15)
+            if (maxz > 0) f1.setParLimits(0, maxz * 0.5, maxz * 1.5)
+            f1.setParLimits(1, peak - 50.0, peak + 50.0)
+            f1.setParLimits(2, 0.01, 200.0)
+            DataFitter.fit(f1, h1, "")
+            fitted_mean  = f1.getParameter(1)
+            fitted_sigma = f1.getParameter(2)
+            println(String.format("[atof_z_fit] %s: retry entries=%d nbins=%d maxbin=%.0f peak=%.1f -> mean=%.1f sigma=%.1f",
+                h1.getName(), entries, h1.getAxis().getNBins(), maxz, peak, fitted_mean, fitted_sigma))
+            if (Math.abs(fitted_sigma - 15.0) < 0.1) {
+                println(String.format("[atof_z_fit] WARNING: %s fit failed even after rebin", h1.getName()))
+            }
         }
 
         return [h1, f1]

--- a/src/main/java/org/jlab/clas/timeline/fitter/ALERTFitter.groovy
+++ b/src/main/java/org/jlab/clas/timeline/fitter/ALERTFitter.groovy
@@ -270,28 +270,41 @@ class ALERTFitter{
 
 
     static F1D atof_z_fitter(H1F h1){
-        double maxz = h1.getBinContent(h1.getMaximumBin())
-        double peak = h1.getAxis().getBinCenter(h1.getMaximumBin())
-        int bin_low  = h1.getAxis().getBin(peak - 100.0)
-        int bin_high = h1.getAxis().getBin(peak + 100.0)
-        double sigma = ALERTFitter.getRestrictedRMS(h1, bin_low, bin_high)
-        if (sigma <= 0 || Double.isNaN(sigma)) sigma = 100.0
+        // Rebin a clone for fitting if low statistics; original h1 is not modified
+        H1F hfit = h1
+        int entries = (int) h1.getEntries()
+        if (entries < 400) {
+            int ngroup = (entries < 200) ? 4 : 2
+            int nbins = h1.getAxis().getNBins()
+            int newbins = nbins / ngroup
+            hfit = new H1F("hfit_rebin", newbins, h1.getAxis().min(), h1.getAxis().max())
+            for (int i = 0; i < newbins; i++) {
+                float sum = 0
+                for (int j = 0; j < ngroup; j++) sum += h1.getBinContent(i * ngroup + j)
+                hfit.setBinContent(i, sum)
+            }
+        }
 
-        def f1 = new F1D("fit:" + h1.getName(), "[amp]*gaus(x,[mean],[sigma])", peak - 2*sigma, peak + 2*sigma)
+        double maxz = hfit.getBinContent(hfit.getMaximumBin())
+        double peak = hfit.getAxis().getBinCenter(hfit.getMaximumBin())
+
+        def f1 = new F1D("fit:" + h1.getName(), "[amp]*gaus(x,[mean],[sigma])", peak - 100, peak + 100)
         f1.setLineColor(33)
         f1.setLineWidth(10)
         f1.setOptStat("1111")
         f1.setParameter(0, maxz)
         f1.setParameter(1, peak)
-        f1.setParameter(2, sigma)
+        f1.setParameter(2, 15.0)
         if (maxz > 0) f1.setParLimits(0, maxz * 0.5, maxz * 1.5)
         f1.setParLimits(1, peak - 50.0, peak + 50.0)
         f1.setParLimits(2, 0.01, 100.0)
 
         PrintStream original = System.out
         System.setOut(new PrintStream(OutputStream.nullOutputStream()))
-        DataFitter.fit(f1, h1, "RQ")
+        DataFitter.fit(f1, hfit, "RQ")
         System.setOut(original)
+
+        if (entries < 400) hfit = null
 
         return f1
     }

--- a/src/main/java/org/jlab/clas/timeline/histograms/ALERT.java
+++ b/src/main/java/org/jlab/clas/timeline/histograms/ALERT.java
@@ -74,7 +74,7 @@ public class ALERT {
       ATOF_z[0].setTitleX("ATOF z (mm)");
       ATOF_z[0].setTitleY("Counts");
       ATOF_z[0].setFillColor(4);
-      ATOF_z_c4[0]= new H1F(String.format("ATOF_z_combined_c4"), String.format("ATOF z with c4"), 40,-200,200);
+      ATOF_z_c4[0]= new H1F(String.format("ATOF_z_combined_c4"), String.format("ATOF z with c4"), 80,-200,200);
       ATOF_z_c4[0].setTitleX("ATOF z (mm)");
       ATOF_z_c4[0].setTitleY("Counts");
       ATOF_z_c4[0].setFillColor(4);
@@ -86,7 +86,7 @@ public class ALERT {
               ATOF_z_sl[gsector].setTitleY("Counts");
               ATOF_z_sl[gsector].setFillColor(4);
 
-              ATOF_z_c4_sl[gsector] = new H1F(String.format("ATOF_z_c4_sector%02d_layer%02d", sector,layer), String.format("ATOF z with C4 sector%02d layer %2d", sector,layer), 40,-200,200);
+              ATOF_z_c4_sl[gsector] = new H1F(String.format("ATOF_z_c4_sector%02d_layer%02d", sector,layer), String.format("ATOF z with C4 sector%02d layer %2d", sector,layer), 80,-200,200);
               ATOF_z_c4_sl[gsector].setTitleX("ATOF z (mm)");
               ATOF_z_c4_sl[gsector].setTitleY("Counts");
               ATOF_z_c4_sl[gsector].setFillColor(4);
@@ -223,7 +223,7 @@ public class ALERT {
           ATOF_Time_sl[gcomponent].fill(time);
       }
 
-      if (component == 10 && Math.abs(time) < 10) {
+      if (component == 10 && Math.abs(time) < 2) {
         float z = atof_hits.getFloat("z", loop);
         ATOF_z[0].fill(z);
         ATOF_z_sl[gsector].fill(z);


### PR DESCRIPTION
- c4 histogram bins from 40 to 80 
- Bar time cut from 10 ns to 2 ns to reduce background
- fixed ±100 mm Gaussian fit range with sigma init at 15 mm
- minimum entries for fitting from 10 to 50
- add rebinning in fitter for low-stats channels (clone histogram)