### PR TITLE
fix(RG-L): adjust QA limits of LTCC `ltcc elec nphe sec` timeline

### DIFF
--- a/src/main/java/org/jlab/clas/timeline/analysis/ltcc/ltcc_nphe_sector.groovy
+++ b/src/main/java/org/jlab/clas/timeline/analysis/ltcc/ltcc_nphe_sector.groovy
@@ -39,6 +39,12 @@ def write() {
     qa_cuts[3] = [12, 18]
     qa_cuts[5] = [12, 18]
   }
+  else if(dataset == 'rgl') {
+    qa_cuts[3] = [13.5, 16.5]
+    qa_cuts[5] = [13.5, 16.5]
+    // FIXME: RG-L would like to have cuts `[4, 7]` for outbending data; for now we set their preferred inbending cuts
+    // til the front-end code can support run-range dependent cuts
+  }
   else {
     qa_cuts[3] = [11, 14]
     qa_cuts[5] = [11, 14]


### PR DESCRIPTION
RG-L requests:
> 13.5 - 16.5 for inbending and 4-7 for outbending

I'm not sure the status of front-end support for run-range dependent horizontal lines on the timeline graph, so for now I put just the inbending cuts.