### PR TITLE
feat: ignore benign warnings from `qtl xcharge` in `qtl error`

### DIFF
--- a/bin/qtl-error
+++ b/bin/qtl-error
@@ -3,11 +3,17 @@
 # - pass an argument to dump only UNIQUE errors
 # - filters out log messages that should not be in stderr
 
+set -euo pipefail
+
 cmd() {
   grep -HE '.*' /farm_out/$LOGNAME/clas12-timeline--*.err |\
     grep -vE '\[DataSourceDump\] --> opened file with events #' |\
     grep -vE 'Picked up _JAVA_OPTIONS:' |\
-    grep --color -E '^.*\.err:'
+    grep -vE 'No valid positive LT neighbor at chunk' |\
+    grep -vE 'fig.\.tight' |\
+    grep -vE 'fig.\.savefig' |\
+    grep -vE 'UserWarning: Creating legend with loc="best"' |\
+    grep --color -E '^.*\.err:' || (echo "no errors found!" && true)
 }
 
 if [ $# -gt 0 ]; then


### PR DESCRIPTION
`qtl error` is used to read error files from batch jobs, ignoring lines we don't care about. Since introducing `--check-charge` to `qtl histogram`, we now have more lines to ignore, mostly from `matplotlib`.